### PR TITLE
Events are no longer generated when no-op changes are made

### DIFF
--- a/plugin/src/lib/csharp_message.cc
+++ b/plugin/src/lib/csharp_message.cc
@@ -284,22 +284,29 @@ void MessageGenerator::Generate(io::Printer* printer, bool isEventSourced) {
     printer->Print("}\n");
     // TODO: Should we put the oneof .proto comments here?
     // It's unclear exactly where they should go.
-	printer->Print(
-	  vars,
-	  "private $property_name$OneofCase $name$Case_ = $property_name$OneofCase.None;\n");
-	WriteGeneratedCodeAttributes(printer);
-	printer->Print(
-	  vars,
-	  "public $property_name$OneofCase $property_name$Case {\n"
-	  "  get { return $name$Case_; }\n"
-	  "}\n\n");
-	WriteGeneratedCodeAttributes(printer);
-	printer->Print(
-	  vars,
-      "public void Clear$property_name$() {\n"
-      "  $name$Case_ = $property_name$OneofCase.None;\n"
-      "  $name$_ = null;\n"
+    printer->Print(
+      vars,
+      "private $property_name$OneofCase $name$Case_ = $property_name$OneofCase.None;\n");
+    WriteGeneratedCodeAttributes(printer);
+    printer->Print(
+      vars,
+      "public $property_name$OneofCase $property_name$Case {\n"
+      "  get { return $name$Case_; }\n"
       "}\n\n");
+    WriteGeneratedCodeAttributes(printer);
+    printer->Print(
+      vars,
+        "public void Clear$property_name$() {\n");
+    if (IsEventSourced()) {
+      printer->Print(vars, "  throw new NotSupportedException(\"Clearing oneofs is not supported by the event system\");\n");
+    }
+    else {
+      printer->Print(
+        vars,
+          "  $name$Case_ = $property_name$OneofCase.None;\n"
+          "  $name$_ = null;\n");
+    }
+    printer->Print(vars, "}\n\n");
   }
 
   // Standard methods

--- a/plugin/src/lib/csharp_message_field.cc
+++ b/plugin/src/lib/csharp_message_field.cc
@@ -272,14 +272,17 @@ void MessageOneofFieldGenerator::GenerateMembers(io::Printer* printer, bool isEv
       if (isInternalSourced) {
         printer->Print(
           variables_,
-          "    if($oneof_name$_ != null) (($type_name$) $oneof_name$_).ClearParent();\n"
+          "    if($oneof_name$Case_ == $oneof_property_name$OneofCase.$property_name$ && $oneof_name$_ != null) (($type_name$) $oneof_name$_).ClearParent();\n"
           "    value.SetParent(Context, new EventPath(Context.Path, $number$));\n");
       }
+      // if (!value.Equals(test_)) {
 
       printer->Print(variables_, "    #if !DISABLE_EVENTS\n");
+      printer->Print(variables_, "    if($oneof_name$Case_ != $oneof_property_name$OneofCase.$property_name$ || !value.Equals($oneof_name$_)) {\n");
       printer->Print(
               variables_,
               "    Context.AddSetEvent($number$, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });\n");
+      printer->Print(variables_, "    }\n");
       printer->Print(variables_,"    #endif\n");
     }
 

--- a/plugin/src/lib/csharp_message_field.cc
+++ b/plugin/src/lib/csharp_message_field.cc
@@ -281,7 +281,7 @@ void MessageOneofFieldGenerator::GenerateMembers(io::Printer* printer, bool isEv
       printer->Print(variables_, "    if($oneof_name$Case_ != $oneof_property_name$OneofCase.$property_name$ || !value.Equals($oneof_name$_)) {\n");
       printer->Print(
               variables_,
-              "    Context.AddSetEvent($number$, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });\n");
+              "      Context.AddSetEvent($number$, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });\n");
       printer->Print(variables_, "    }\n");
       printer->Print(variables_,"    #endif\n");
     }

--- a/plugin/src/lib/csharp_message_field.cc
+++ b/plugin/src/lib/csharp_message_field.cc
@@ -89,9 +89,11 @@ void MessageFieldGenerator::GenerateMembers(io::Printer* printer, bool isEventSo
     printer->Print(
        variables_,
        "    #if !DISABLE_EVENTS\n");
+    printer->Print(variables_, "    if(value == null || !value.Equals($name$_)) {\n");
     printer->Print(
        variables_,
-       "    Context.AddSetEvent($number$, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });\n");
+       "      Context.AddSetEvent($number$, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });\n");
+    printer->Print(variables_, "    }\n");
     printer->Print(
        variables_,
        "    #endif\n");

--- a/plugin/src/lib/csharp_primitive_field.cc
+++ b/plugin/src/lib/csharp_primitive_field.cc
@@ -112,7 +112,7 @@ void PrimitiveFieldGenerator::GenerateMembers(io::Printer* printer, bool isEvent
             printer->Print(variables_, "    if($name$_ != value) {\n");
             printer->Print(
               variables_,
-              "    Context.AddSetEvent($number$, new zpr.EventSource.EventContent { $data_value$ = value });\n");
+              "      Context.AddSetEvent($number$, new zpr.EventSource.EventContent { $data_value$ = value });\n");
             printer->Print(variables_, "    }\n");
             printer->Print(variables_,"    #endif\n");
           }
@@ -121,7 +121,7 @@ void PrimitiveFieldGenerator::GenerateMembers(io::Printer* printer, bool isEvent
             printer->Print(variables_, "    if($name$_ != value) {\n");
             printer->Print(
               variables_,
-              "    Context.AddSetEvent($number$, new zpr.EventSource.EventContent { $data_value$ = pb::ProtoPreconditions.CheckNotNull(value, \"value\") });\n");
+              "      Context.AddSetEvent($number$, new zpr.EventSource.EventContent { $data_value$ = pb::ProtoPreconditions.CheckNotNull(value, \"value\") });\n");
             printer->Print(variables_, "    }\n");
             printer->Print(variables_,"    #endif\n");
           }

--- a/plugin/src/lib/csharp_primitive_field.cc
+++ b/plugin/src/lib/csharp_primitive_field.cc
@@ -84,10 +84,12 @@ void PrimitiveFieldGenerator::GenerateMembers(io::Printer* printer, bool isEvent
       switch (descriptor_->type()) {
         case FieldDescriptor::TYPE_ENUM:
           printer->Print(variables_, "    #if !DISABLE_EVENTS\n");
+          printer->Print(variables_, "    if($name$_ != value) {\n");
           printer->Print(
               variables_,
-              "    Context.AddSetEvent($number$, new zpr.EventSource.EventContent { $data_value$ = (uint) value });\n");
-          printer->Print(variables_,"    #endif\n");
+              "      Context.AddSetEvent($number$, new zpr.EventSource.EventContent { $data_value$ = (uint) value });\n");
+          printer->Print(variables_, "    }\n");
+          printer->Print(variables_, "    #endif\n");
           break;
         case FieldDescriptor::TYPE_DOUBLE:
         case FieldDescriptor::TYPE_FLOAT:
@@ -107,16 +109,20 @@ void PrimitiveFieldGenerator::GenerateMembers(io::Printer* printer, bool isEvent
         {
           if (is_value_type) {
             printer->Print(variables_, "    #if !DISABLE_EVENTS\n");
+            printer->Print(variables_, "    if($name$_ != value) {\n");
             printer->Print(
               variables_,
               "    Context.AddSetEvent($number$, new zpr.EventSource.EventContent { $data_value$ = value });\n");
+            printer->Print(variables_, "    }\n");
             printer->Print(variables_,"    #endif\n");
           }
           else {
             printer->Print(variables_, "    #if !DISABLE_EVENTS\n");
+            printer->Print(variables_, "    if($name$_ != value) {\n");
             printer->Print(
               variables_,
               "    Context.AddSetEvent($number$, new zpr.EventSource.EventContent { $data_value$ = pb::ProtoPreconditions.CheckNotNull(value, \"value\") });\n");
+            printer->Print(variables_, "    }\n");
             printer->Print(variables_,"    #endif\n");
           }
         }
@@ -313,16 +319,20 @@ void PrimitiveOneofFieldGenerator::GenerateMembers(io::Printer* printer, bool is
         {
           if (is_value_type) {
             printer->Print(variables_, "    #if !DISABLE_EVENTS\n");
+            printer->Print(variables_, "    if($oneof_name$Case_ != $oneof_property_name$OneofCase.$property_name$ || value != ($type_name$) $oneof_name$_) {\n");
             printer->Print(
               variables_,
-              "    Context.AddSetEvent($number$, new zpr.EventSource.EventContent { $data_value$ = value });\n");
+              "      Context.AddSetEvent($number$, new zpr.EventSource.EventContent { $data_value$ = value });\n");
+            printer->Print(variables_, "    }\n");
             printer->Print(variables_,"    #endif\n");
           }
           else {
             printer->Print(variables_, "    #if !DISABLE_EVENTS\n");
+            printer->Print(variables_, "    if($oneof_name$Case_ != $oneof_property_name$OneofCase.$property_name$ || value != ($type_name$) $oneof_name$_) {\n");
             printer->Print(
               variables_,
-              "    Context.AddSetEvent($number$, new zpr.EventSource.EventContent { $data_value$ = pb::ProtoPreconditions.CheckNotNull(value, \"value\") });\n");
+              "      Context.AddSetEvent($number$, new zpr.EventSource.EventContent { $data_value$ = pb::ProtoPreconditions.CheckNotNull(value, \"value\") });\n");
+            printer->Print(variables_, "    }\n");
             printer->Print(variables_,"    #endif\n");
           }
         }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
@@ -350,7 +350,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         value.SetParent(Context, new EventPath(Context.Path, 8));
         #if !DISABLE_EVENTS
         if(testCase_ != TestOneofCase.Maybefoo || !value.Equals(test_)) {
-        Context.AddSetEvent(8, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+          Context.AddSetEvent(8, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
         }
         #endif
         test_ = value;
@@ -413,7 +413,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(fieldBool_ != value) {
-        Context.AddSetEvent(12, new zpr.EventSource.EventContent { BoolData = value });
+          Context.AddSetEvent(12, new zpr.EventSource.EventContent { BoolData = value });
         }
         #endif
         fieldBool_ = value;
@@ -1001,7 +1001,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(long_ != value) {
-        Context.AddSetEvent(1, new zpr.EventSource.EventContent { I64 = value });
+          Context.AddSetEvent(1, new zpr.EventSource.EventContent { I64 = value });
         }
         #endif
         long_ = value;
@@ -1017,7 +1017,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(str_ != value) {
-        Context.AddSetEvent(2, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+          Context.AddSetEvent(2, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
         }
         #endif
         str_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
@@ -1268,7 +1268,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           set {
             #if !DISABLE_EVENTS
             if(hi_ != value) {
-            Context.AddSetEvent(1, new zpr.EventSource.EventContent { I32 = value });
+              Context.AddSetEvent(1, new zpr.EventSource.EventContent { I32 = value });
             }
             #endif
             hi_ = value;
@@ -1660,7 +1660,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(a_ != value) {
-        Context.AddSetEvent(1, new zpr.EventSource.EventContent { U32 = value });
+          Context.AddSetEvent(1, new zpr.EventSource.EventContent { U32 = value });
         }
         #endif
         a_ = value;
@@ -1676,7 +1676,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(b_ != value) {
-        Context.AddSetEvent(2, new zpr.EventSource.EventContent { I32 = value });
+          Context.AddSetEvent(2, new zpr.EventSource.EventContent { I32 = value });
         }
         #endif
         b_ = value;
@@ -1692,7 +1692,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(c_ != value) {
-        Context.AddSetEvent(3, new zpr.EventSource.EventContent { F64 = value });
+          Context.AddSetEvent(3, new zpr.EventSource.EventContent { F64 = value });
         }
         #endif
         c_ = value;
@@ -1708,7 +1708,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(d_ != value) {
-        Context.AddSetEvent(4, new zpr.EventSource.EventContent { F32 = value });
+          Context.AddSetEvent(4, new zpr.EventSource.EventContent { F32 = value });
         }
         #endif
         d_ = value;
@@ -1724,7 +1724,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(e_ != value) {
-        Context.AddSetEvent(5, new zpr.EventSource.EventContent { SF64 = value });
+          Context.AddSetEvent(5, new zpr.EventSource.EventContent { SF64 = value });
         }
         #endif
         e_ = value;
@@ -1740,7 +1740,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(f_ != value) {
-        Context.AddSetEvent(6, new zpr.EventSource.EventContent { SF32 = value });
+          Context.AddSetEvent(6, new zpr.EventSource.EventContent { SF32 = value });
         }
         #endif
         f_ = value;
@@ -1756,7 +1756,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(g_ != value) {
-        Context.AddSetEvent(7, new zpr.EventSource.EventContent { R64 = value });
+          Context.AddSetEvent(7, new zpr.EventSource.EventContent { R64 = value });
         }
         #endif
         g_ = value;
@@ -1772,7 +1772,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(h_ != value) {
-        Context.AddSetEvent(8, new zpr.EventSource.EventContent { R32 = value });
+          Context.AddSetEvent(8, new zpr.EventSource.EventContent { R32 = value });
         }
         #endif
         h_ = value;
@@ -1788,7 +1788,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(i_ != value) {
-        Context.AddSetEvent(9, new zpr.EventSource.EventContent { BoolData = value });
+          Context.AddSetEvent(9, new zpr.EventSource.EventContent { BoolData = value });
         }
         #endif
         i_ = value;
@@ -1804,7 +1804,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(j_ != value) {
-        Context.AddSetEvent(10, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+          Context.AddSetEvent(10, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
         }
         #endif
         j_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
@@ -1820,7 +1820,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(k_ != value) {
-        Context.AddSetEvent(11, new zpr.EventSource.EventContent { ByteData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+          Context.AddSetEvent(11, new zpr.EventSource.EventContent { ByteData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
         }
         #endif
         k_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
@@ -1836,7 +1836,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(l_ != value) {
-        Context.AddSetEvent(12, new zpr.EventSource.EventContent { I64 = value });
+          Context.AddSetEvent(12, new zpr.EventSource.EventContent { I64 = value });
         }
         #endif
         l_ = value;
@@ -1852,7 +1852,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(m_ != value) {
-        Context.AddSetEvent(13, new zpr.EventSource.EventContent { U64 = value });
+          Context.AddSetEvent(13, new zpr.EventSource.EventContent { U64 = value });
         }
         #endif
         m_ = value;
@@ -1868,7 +1868,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(n_ != value) {
-        Context.AddSetEvent(14, new zpr.EventSource.EventContent { SI32 = value });
+          Context.AddSetEvent(14, new zpr.EventSource.EventContent { SI32 = value });
         }
         #endif
         n_ = value;
@@ -1884,7 +1884,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(o_ != value) {
-        Context.AddSetEvent(15, new zpr.EventSource.EventContent { SI64 = value });
+          Context.AddSetEvent(15, new zpr.EventSource.EventContent { SI64 = value });
         }
         #endif
         o_ = value;

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
@@ -193,7 +193,9 @@ namespace Com.Zynga.Runtime.Protobuf {
         if(bar_ != null) bar_.ClearParent();
         value.SetParent(Context, new EventPath(Context.Path, 1));
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(1, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(bar_)) {
+          Context.AddSetEvent(1, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         bar_ = value;
       }
@@ -209,7 +211,9 @@ namespace Com.Zynga.Runtime.Protobuf {
         if(foo_ != null) foo_.ClearParent();
         value.SetParent(Context, new EventPath(Context.Path, 2));
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(2, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(foo_)) {
+          Context.AddSetEvent(2, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         foo_ = value;
       }
@@ -398,7 +402,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return zam_; }
       set {
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(11, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(zam_)) {
+          Context.AddSetEvent(11, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         zam_ = value;
       }
@@ -428,7 +434,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return timestamp_; }
       set {
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(13, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(timestamp_)) {
+          Context.AddSetEvent(13, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         timestamp_ = value;
       }
@@ -442,7 +450,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return duration_; }
       set {
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(14, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(duration_)) {
+          Context.AddSetEvent(14, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         duration_ = value;
       }
@@ -458,7 +468,9 @@ namespace Com.Zynga.Runtime.Protobuf {
         if(allPrims_ != null) allPrims_.ClearParent();
         value.SetParent(Context, new EventPath(Context.Path, 15));
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(15, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(allPrims_)) {
+          Context.AddSetEvent(15, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         allPrims_ = value;
       }
@@ -474,7 +486,9 @@ namespace Com.Zynga.Runtime.Protobuf {
         if(testBlob_ != null) testBlob_.ClearParent();
         value.SetParent(Context, new EventPath(Context.Path, 16));
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(16, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(testBlob_)) {
+          Context.AddSetEvent(16, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         testBlob_ = value;
       }
@@ -1034,7 +1048,9 @@ namespace Com.Zynga.Runtime.Protobuf {
         if(foo_ != null) foo_.ClearParent();
         value.SetParent(Context, new EventPath(Context.Path, 3));
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(3, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(foo_)) {
+          Context.AddSetEvent(3, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         foo_ = value;
       }
@@ -1480,7 +1496,9 @@ namespace Com.Zynga.Runtime.Protobuf {
         if(foo_ != null) foo_.ClearParent();
         value.SetParent(Context, new EventPath(Context.Path, 1));
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(1, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(foo_)) {
+          Context.AddSetEvent(1, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         foo_ = value;
       }
@@ -2361,7 +2379,9 @@ namespace Com.Zynga.Runtime.Protobuf {
         if(primitives_ != null) primitives_.ClearParent();
         value.SetParent(Context, new EventPath(Context.Path, 2));
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(2, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(primitives_)) {
+          Context.AddSetEvent(2, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         primitives_ = value;
       }
@@ -2393,7 +2413,9 @@ namespace Com.Zynga.Runtime.Protobuf {
         if(bar_ != null) bar_.ClearParent();
         value.SetParent(Context, new EventPath(Context.Path, 4));
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(4, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(bar_)) {
+          Context.AddSetEvent(4, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         bar_ = value;
       }
@@ -2650,7 +2672,9 @@ namespace Com.Zynga.Runtime.Protobuf {
         if(primitives_ != null) primitives_.ClearParent();
         value.SetParent(Context, new EventPath(Context.Path, 2));
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(2, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(primitives_)) {
+          Context.AddSetEvent(2, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         primitives_ = value;
       }
@@ -2682,7 +2706,9 @@ namespace Com.Zynga.Runtime.Protobuf {
         if(bar_ != null) bar_.ClearParent();
         value.SetParent(Context, new EventPath(Context.Path, 4));
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(4, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(bar_)) {
+          Context.AddSetEvent(4, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         bar_ = value;
       }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
@@ -346,10 +346,12 @@ namespace Com.Zynga.Runtime.Protobuf {
     public global::Com.Zynga.Runtime.Protobuf.Foo Maybefoo {
       get { return testCase_ == TestOneofCase.Maybefoo ? (global::Com.Zynga.Runtime.Protobuf.Foo) test_ : null; }
       set {
-        if(test_ != null) ((global::Com.Zynga.Runtime.Protobuf.Foo) test_).ClearParent();
+        if(testCase_ == TestOneofCase.Maybefoo && test_ != null) ((global::Com.Zynga.Runtime.Protobuf.Foo) test_).ClearParent();
         value.SetParent(Context, new EventPath(Context.Path, 8));
         #if !DISABLE_EVENTS
+        if(testCase_ != TestOneofCase.Maybefoo || !value.Equals(test_)) {
         Context.AddSetEvent(8, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         test_ = value;
         testCase_ = value == null ? TestOneofCase.None : TestOneofCase.Maybefoo;
@@ -363,7 +365,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return testCase_ == TestOneofCase.Maybeint ? (int) test_ : 0; }
       set {
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(9, new zpr.EventSource.EventContent { I32 = value });
+        if(testCase_ != TestOneofCase.Maybeint || value != (int) test_) {
+          Context.AddSetEvent(9, new zpr.EventSource.EventContent { I32 = value });
+        }
         #endif
         test_ = value;
         testCase_ = TestOneofCase.Maybeint;
@@ -377,7 +381,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return testCase_ == TestOneofCase.Maybestring ? (string) test_ : ""; }
       set {
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(10, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+        if(testCase_ != TestOneofCase.Maybestring || value != (string) test_) {
+          Context.AddSetEvent(10, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+        }
         #endif
         test_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         testCase_ = TestOneofCase.Maybestring;
@@ -406,7 +412,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return fieldBool_; }
       set {
         #if !DISABLE_EVENTS
+        if(fieldBool_ != value) {
         Context.AddSetEvent(12, new zpr.EventSource.EventContent { BoolData = value });
+        }
         #endif
         fieldBool_ = value;
       }
@@ -488,8 +496,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void ClearTest() {
-      testCase_ = TestOneofCase.None;
-      test_ = null;
+      throw new NotSupportedException("Clearing oneofs is not supported by the event system");
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -993,7 +1000,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return long_; }
       set {
         #if !DISABLE_EVENTS
+        if(long_ != value) {
         Context.AddSetEvent(1, new zpr.EventSource.EventContent { I64 = value });
+        }
         #endif
         long_ = value;
       }
@@ -1007,7 +1016,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return str_; }
       set {
         #if !DISABLE_EVENTS
+        if(str_ != value) {
         Context.AddSetEvent(2, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+        }
         #endif
         str_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
@@ -1037,7 +1048,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return enumero_; }
       set {
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(4, new zpr.EventSource.EventContent { U32 = (uint) value });
+        if(enumero_ != value) {
+          Context.AddSetEvent(4, new zpr.EventSource.EventContent { U32 = (uint) value });
+        }
         #endif
         enumero_ = value;
       }
@@ -1051,7 +1064,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return okay_; }
       set {
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(5, new zpr.EventSource.EventContent { U32 = (uint) value });
+        if(okay_ != value) {
+          Context.AddSetEvent(5, new zpr.EventSource.EventContent { U32 = (uint) value });
+        }
         #endif
         okay_ = value;
       }
@@ -1252,7 +1267,9 @@ namespace Com.Zynga.Runtime.Protobuf {
           get { return hi_; }
           set {
             #if !DISABLE_EVENTS
+            if(hi_ != value) {
             Context.AddSetEvent(1, new zpr.EventSource.EventContent { I32 = value });
+            }
             #endif
             hi_ = value;
           }
@@ -1642,7 +1659,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return a_; }
       set {
         #if !DISABLE_EVENTS
+        if(a_ != value) {
         Context.AddSetEvent(1, new zpr.EventSource.EventContent { U32 = value });
+        }
         #endif
         a_ = value;
       }
@@ -1656,7 +1675,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return b_; }
       set {
         #if !DISABLE_EVENTS
+        if(b_ != value) {
         Context.AddSetEvent(2, new zpr.EventSource.EventContent { I32 = value });
+        }
         #endif
         b_ = value;
       }
@@ -1670,7 +1691,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return c_; }
       set {
         #if !DISABLE_EVENTS
+        if(c_ != value) {
         Context.AddSetEvent(3, new zpr.EventSource.EventContent { F64 = value });
+        }
         #endif
         c_ = value;
       }
@@ -1684,7 +1707,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return d_; }
       set {
         #if !DISABLE_EVENTS
+        if(d_ != value) {
         Context.AddSetEvent(4, new zpr.EventSource.EventContent { F32 = value });
+        }
         #endif
         d_ = value;
       }
@@ -1698,7 +1723,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return e_; }
       set {
         #if !DISABLE_EVENTS
+        if(e_ != value) {
         Context.AddSetEvent(5, new zpr.EventSource.EventContent { SF64 = value });
+        }
         #endif
         e_ = value;
       }
@@ -1712,7 +1739,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return f_; }
       set {
         #if !DISABLE_EVENTS
+        if(f_ != value) {
         Context.AddSetEvent(6, new zpr.EventSource.EventContent { SF32 = value });
+        }
         #endif
         f_ = value;
       }
@@ -1726,7 +1755,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return g_; }
       set {
         #if !DISABLE_EVENTS
+        if(g_ != value) {
         Context.AddSetEvent(7, new zpr.EventSource.EventContent { R64 = value });
+        }
         #endif
         g_ = value;
       }
@@ -1740,7 +1771,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return h_; }
       set {
         #if !DISABLE_EVENTS
+        if(h_ != value) {
         Context.AddSetEvent(8, new zpr.EventSource.EventContent { R32 = value });
+        }
         #endif
         h_ = value;
       }
@@ -1754,7 +1787,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return i_; }
       set {
         #if !DISABLE_EVENTS
+        if(i_ != value) {
         Context.AddSetEvent(9, new zpr.EventSource.EventContent { BoolData = value });
+        }
         #endif
         i_ = value;
       }
@@ -1768,7 +1803,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return j_; }
       set {
         #if !DISABLE_EVENTS
+        if(j_ != value) {
         Context.AddSetEvent(10, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+        }
         #endif
         j_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
@@ -1782,7 +1819,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return k_; }
       set {
         #if !DISABLE_EVENTS
+        if(k_ != value) {
         Context.AddSetEvent(11, new zpr.EventSource.EventContent { ByteData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+        }
         #endif
         k_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
@@ -1796,7 +1835,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return l_; }
       set {
         #if !DISABLE_EVENTS
+        if(l_ != value) {
         Context.AddSetEvent(12, new zpr.EventSource.EventContent { I64 = value });
+        }
         #endif
         l_ = value;
       }
@@ -1810,7 +1851,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return m_; }
       set {
         #if !DISABLE_EVENTS
+        if(m_ != value) {
         Context.AddSetEvent(13, new zpr.EventSource.EventContent { U64 = value });
+        }
         #endif
         m_ = value;
       }
@@ -1824,7 +1867,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return n_; }
       set {
         #if !DISABLE_EVENTS
+        if(n_ != value) {
         Context.AddSetEvent(14, new zpr.EventSource.EventContent { SI32 = value });
+        }
         #endif
         n_ = value;
       }
@@ -1838,7 +1883,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return o_; }
       set {
         #if !DISABLE_EVENTS
+        if(o_ != value) {
         Context.AddSetEvent(15, new zpr.EventSource.EventContent { SI64 = value });
+        }
         #endif
         o_ = value;
       }
@@ -2328,7 +2375,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return enumero_; }
       set {
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(3, new zpr.EventSource.EventContent { U32 = (uint) value });
+        if(enumero_ != value) {
+          Context.AddSetEvent(3, new zpr.EventSource.EventContent { U32 = (uint) value });
+        }
         #endif
         enumero_ = value;
       }
@@ -2615,7 +2664,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return enumero_; }
       set {
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(3, new zpr.EventSource.EventContent { U32 = (uint) value });
+        if(enumero_ != value) {
+          Context.AddSetEvent(3, new zpr.EventSource.EventContent { U32 = (uint) value });
+        }
         #endif
         enumero_ = value;
       }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
@@ -256,7 +256,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return data_; }
       set {
         #if !DISABLE_EVENTS
+        if(data_ != value) {
         Context.AddSetEvent(1, new zpr.EventSource.EventContent { I32 = value });
+        }
         #endif
         data_ = value;
       }
@@ -452,7 +454,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return eventId_; }
       set {
         #if !DISABLE_EVENTS
+        if(eventId_ != value) {
         Context.AddSetEvent(1, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+        }
         #endif
         eventId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
@@ -465,7 +469,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return testOneofCase_ == TestOneofOneofCase.Foo ? (string) testOneof_ : ""; }
       set {
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(2, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+        if(testOneofCase_ != TestOneofOneofCase.Foo || value != (string) testOneof_) {
+          Context.AddSetEvent(2, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+        }
         #endif
         testOneof_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         testOneofCase_ = TestOneofOneofCase.Foo;
@@ -478,10 +484,12 @@ namespace Com.Zynga.Runtime.Protobuf {
     public global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage Internal {
       get { return testOneofCase_ == TestOneofOneofCase.Internal ? (global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage) testOneof_ : null; }
       set {
-        if(testOneof_ != null) ((global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage) testOneof_).ClearParent();
+        if(testOneofCase_ == TestOneofOneofCase.Internal && testOneof_ != null) ((global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage) testOneof_).ClearParent();
         value.SetParent(Context, new EventPath(Context.Path, 3));
         #if !DISABLE_EVENTS
+        if(testOneofCase_ != TestOneofOneofCase.Internal || !value.Equals(testOneof_)) {
         Context.AddSetEvent(3, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         testOneof_ = value;
         testOneofCase_ = value == null ? TestOneofOneofCase.None : TestOneofOneofCase.Internal;
@@ -496,7 +504,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return testEvent_; }
       set {
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(4, new zpr.EventSource.EventContent { U32 = (uint) value });
+        if(testEvent_ != value) {
+          Context.AddSetEvent(4, new zpr.EventSource.EventContent { U32 = (uint) value });
+        }
         #endif
         testEvent_ = value;
       }
@@ -665,7 +675,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return testStringNoChecksum_; }
       set {
         #if !DISABLE_EVENTS
+        if(testStringNoChecksum_ != value) {
         Context.AddSetEvent(12, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+        }
         #endif
         testStringNoChecksum_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
@@ -679,7 +691,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return testBytesField_; }
       set {
         #if !DISABLE_EVENTS
+        if(testBytesField_ != value) {
         Context.AddSetEvent(13, new zpr.EventSource.EventContent { ByteData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+        }
         #endif
         testBytesField_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
@@ -714,8 +728,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public void ClearTestOneof() {
-      testOneofCase_ = TestOneofOneofCase.None;
-      testOneof_ = null;
+      throw new NotSupportedException("Clearing oneofs is not supported by the event system");
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1077,7 +1090,9 @@ namespace Com.Zynga.Runtime.Protobuf {
           get { return data_; }
           set {
             #if !DISABLE_EVENTS
+            if(data_ != value) {
             Context.AddSetEvent(1, new zpr.EventSource.EventContent { I32 = value });
+            }
             #endif
             data_ = value;
           }
@@ -1290,7 +1305,9 @@ namespace Com.Zynga.Runtime.Protobuf {
           get { return bodyCase_ == BodyOneofCase.Foo ? (string) body_ : ""; }
           set {
             #if !DISABLE_EVENTS
-            Context.AddSetEvent(1, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+            if(bodyCase_ != BodyOneofCase.Foo || value != (string) body_) {
+              Context.AddSetEvent(1, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+            }
             #endif
             body_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
             bodyCase_ = BodyOneofCase.Foo;
@@ -1304,7 +1321,9 @@ namespace Com.Zynga.Runtime.Protobuf {
           get { return bodyCase_ == BodyOneofCase.Internal ? (global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage) body_ : null; }
           set {
             #if !DISABLE_EVENTS
+            if(bodyCase_ != BodyOneofCase.Internal || !value.Equals(body_)) {
             Context.AddSetEvent(2, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+            }
             #endif
             body_ = value;
             bodyCase_ = value == null ? BodyOneofCase.None : BodyOneofCase.Internal;
@@ -1326,8 +1345,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void ClearBody() {
-          bodyCase_ = BodyOneofCase.None;
-          body_ = null;
+          throw new NotSupportedException("Clearing oneofs is not supported by the event system");
         }
 
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
@@ -257,7 +257,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(data_ != value) {
-        Context.AddSetEvent(1, new zpr.EventSource.EventContent { I32 = value });
+          Context.AddSetEvent(1, new zpr.EventSource.EventContent { I32 = value });
         }
         #endif
         data_ = value;
@@ -455,7 +455,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(eventId_ != value) {
-        Context.AddSetEvent(1, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+          Context.AddSetEvent(1, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
         }
         #endif
         eventId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
@@ -488,7 +488,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         value.SetParent(Context, new EventPath(Context.Path, 3));
         #if !DISABLE_EVENTS
         if(testOneofCase_ != TestOneofOneofCase.Internal || !value.Equals(testOneof_)) {
-        Context.AddSetEvent(3, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+          Context.AddSetEvent(3, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
         }
         #endif
         testOneof_ = value;
@@ -676,7 +676,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(testStringNoChecksum_ != value) {
-        Context.AddSetEvent(12, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+          Context.AddSetEvent(12, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
         }
         #endif
         testStringNoChecksum_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
@@ -692,7 +692,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(testBytesField_ != value) {
-        Context.AddSetEvent(13, new zpr.EventSource.EventContent { ByteData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+          Context.AddSetEvent(13, new zpr.EventSource.EventContent { ByteData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
         }
         #endif
         testBytesField_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
@@ -1091,7 +1091,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           set {
             #if !DISABLE_EVENTS
             if(data_ != value) {
-            Context.AddSetEvent(1, new zpr.EventSource.EventContent { I32 = value });
+              Context.AddSetEvent(1, new zpr.EventSource.EventContent { I32 = value });
             }
             #endif
             data_ = value;
@@ -1322,7 +1322,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           set {
             #if !DISABLE_EVENTS
             if(bodyCase_ != BodyOneofCase.Internal || !value.Equals(body_)) {
-            Context.AddSetEvent(2, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+              Context.AddSetEvent(2, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
             }
             #endif
             body_ = value;

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
@@ -614,7 +614,9 @@ namespace Com.Zynga.Runtime.Protobuf {
         if(data_ != null) data_.ClearParent();
         value.SetParent(Context, new EventPath(Context.Path, 9));
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(9, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(data_)) {
+          Context.AddSetEvent(9, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         data_ = value;
       }
@@ -661,7 +663,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return testNonMessage_; }
       set {
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(11, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(testNonMessage_)) {
+          Context.AddSetEvent(11, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         testNonMessage_ = value;
       }
@@ -707,7 +711,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return date_; }
       set {
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(14, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(date_)) {
+          Context.AddSetEvent(14, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         date_ = value;
       }
@@ -1108,7 +1114,9 @@ namespace Com.Zynga.Runtime.Protobuf {
             if(dataTwo_ != null) dataTwo_.ClearParent();
             value.SetParent(Context, new EventPath(Context.Path, 2));
             #if !DISABLE_EVENTS
-            Context.AddSetEvent(2, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+            if(value == null || !value.Equals(dataTwo_)) {
+              Context.AddSetEvent(2, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+            }
             #endif
             dataTwo_ = value;
           }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/DeltaTests.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/DeltaTests.cs
@@ -262,8 +262,13 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 
 		[Fact]
 		public void ShouldNotGenerateDeltasForNoOpsOnPrimitiveFields() {
-			var blob = new TestBlob {Foo = new Foo()};
+			var blob = new TestBlob();
+			blob.Foo = new Foo();
+			AssertGenerated(blob);
 			blob.ClearEvents();
+
+			blob.Foo = new Foo();
+			AssertNotGenerated(blob);
 
 			blob.Foo.Long = 0L;
 			AssertNotGenerated(blob);

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/DeltaTests.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/DeltaTests.cs
@@ -204,14 +204,150 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 
 		[Fact]
 		public void ShouldNotGenerateDeltasForNoOpsOnMaps() {
-			/*
 			var blob = new TestBlob();
-			blob.IntToString.Add(0, "a");
+			blob.IntToString[0] = "a";
 			AssertGenerated(blob);
+			blob.ClearEvents();
 
-			blob.IntToString.Add(0, "a");
+			blob.IntToString[0] = "a";
 			AssertNotGenerated(blob);
-			*/
+
+			blob.IntToString[0] = "b";
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.IntToString[0] = "a";
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.IntToString.Remove(1);
+			AssertNotGenerated(blob);
+
+			blob.IntToString.Remove(0);
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.IntToString.Remove(0);
+			AssertNotGenerated(blob);
+
+			blob.StringToFoo["a"] = new Foo();
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.StringToFoo["a"] = new Foo {Long = 1};
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.StringToFoo["a"] = new Foo {Long = 1, Str = "test"};
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.StringToFoo["a"] = new Foo {Long = 1, Str = "test"};
+			AssertNotGenerated(blob);
+
+			blob.StringToFoo["a"] = new Foo();
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.StringToFoo.Remove("a");
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.StringToFoo.Remove("a");
+			AssertNotGenerated(blob);
+
+			blob.StringToFoo.Remove("b");
+			AssertNotGenerated(blob);
+		}
+
+		[Fact]
+		public void ShouldNotGenerateDeltasForNoOpsOnPrimitiveFields() {
+			var blob = new TestBlob {Foo = new Foo()};
+			blob.ClearEvents();
+
+			blob.Foo.Long = 0L;
+			AssertNotGenerated(blob);
+
+			blob.Foo.Long = 1L;
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.Foo.Long = 1L;
+			AssertNotGenerated(blob);
+
+			blob.Foo.Long = 0L;
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.Foo.Str = "1 long please";
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.Foo.Str = "1 long please";
+			AssertNotGenerated(blob);
+
+			blob.Foo.Str = "";
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.Foo.Str = "";
+			AssertNotGenerated(blob);
+		}
+
+		[Fact]
+		public void ShouldNotGenerateDeltasForNoOpsOnOneOfs() {
+			var blob = new TestBlob();
+
+			blob.Maybestring = "hello";
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.Maybestring = "hello";
+			AssertNotGenerated(blob);
+
+			blob.Maybefoo = new Foo {Long = 2L};
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.Maybefoo = new Foo {Long = 2L};
+			AssertNotGenerated(blob);
+
+			blob.Maybefoo = new Foo {Long = 2L, Str = "hi"};
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.Maybeint = 2;
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.Maybeint = 2;
+			AssertNotGenerated(blob);
+		}
+
+		[Fact]
+		public void ShouldNotGenerateDeltasForNoOpsOnLists() {
+			var blob = new TestBlob();
+
+			blob.Ilist.Add(1);
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.Ilist[0] = 1;
+			AssertNotGenerated(blob);
+
+			blob.Foolist.Add(new Foo { Long = 1 });
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.Foolist[0] = new Foo { Long = 1 };
+			AssertNotGenerated(blob);
+
+			blob.Slist.Add("hello");
+			AssertGenerated(blob);
+			blob.ClearEvents();
+
+			blob.Slist[0] = "hello";
+			AssertNotGenerated(blob);
 		}
 
 		private RecursiveMap CreateRecursiveMap(int depth) {

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleList.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleList.cs
@@ -243,7 +243,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return h_; }
       set {
         #if !DISABLE_EVENTS
+        if(h_ != value) {
         Context.AddSetEvent(1, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+        }
         #endif
         h_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleList.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleList.cs
@@ -244,7 +244,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(h_ != value) {
-        Context.AddSetEvent(1, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+          Context.AddSetEvent(1, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
         }
         #endif
         h_ = pb::ProtoPreconditions.CheckNotNull(value, "value");

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMap.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMap.cs
@@ -267,7 +267,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return h_; }
       set {
         #if !DISABLE_EVENTS
+        if(h_ != value) {
         Context.AddSetEvent(1, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+        }
         #endif
         h_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMap.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMap.cs
@@ -268,7 +268,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(h_ != value) {
-        Context.AddSetEvent(1, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+          Context.AddSetEvent(1, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
         }
         #endif
         h_ = pb::ProtoPreconditions.CheckNotNull(value, "value");

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
@@ -108,7 +108,9 @@ namespace Com.Zynga.Runtime.Protobuf {
         if(b_ != null) b_.ClearParent();
         value.SetParent(Context, new EventPath(Context.Path, 2));
         #if !DISABLE_EVENTS
-        Context.AddSetEvent(2, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        if(value == null || !value.Equals(b_)) {
+          Context.AddSetEvent(2, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
         #endif
         b_ = value;
       }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
@@ -91,7 +91,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(a_ != value) {
-        Context.AddSetEvent(1, new zpr.EventSource.EventContent { I32 = value });
+          Context.AddSetEvent(1, new zpr.EventSource.EventContent { I32 = value });
         }
         #endif
         a_ = value;
@@ -294,7 +294,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       set {
         #if !DISABLE_EVENTS
         if(c_ != value) {
-        Context.AddSetEvent(3, new zpr.EventSource.EventContent { I64 = value });
+          Context.AddSetEvent(3, new zpr.EventSource.EventContent { I64 = value });
         }
         #endif
         c_ = value;

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
@@ -90,7 +90,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return a_; }
       set {
         #if !DISABLE_EVENTS
+        if(a_ != value) {
         Context.AddSetEvent(1, new zpr.EventSource.EventContent { I32 = value });
+        }
         #endif
         a_ = value;
       }
@@ -291,7 +293,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       get { return c_; }
       set {
         #if !DISABLE_EVENTS
+        if(c_ != value) {
         Context.AddSetEvent(3, new zpr.EventSource.EventContent { I64 = value });
+        }
         #endif
         c_ = value;
       }

--- a/runtime/src/Zynga.Protobuf.Runtime/EventMapField.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventMapField.cs
@@ -78,9 +78,14 @@ namespace Zynga.Protobuf.Runtime {
 		public TValue this[TKey key] {
 			get { return _internal[key]; }
 			set {
+				#if !DISABLE_EVENTS
+				var generateEvent = !_internal.ContainsKey(key) || !_internal[key].Equals(value);
+				#endif
 				InternalReplace(key, value);
 				#if !DISABLE_EVENTS
-				ReplaceMapEvent(key, value);
+				if (generateEvent) {
+					ReplaceMapEvent(key, value);
+				}
 				#endif
 			}
 		}

--- a/runtime/src/Zynga.Protobuf.Runtime/EventRepeatedField.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventRepeatedField.cs
@@ -166,9 +166,14 @@ namespace Zynga.Protobuf.Runtime {
 		public T this[int index] {
 			get { return _internal[index]; }
 			set {
+				#if !DISABLE_EVENTS
+				var generateEvent = !value.Equals(_internal[index]);
+				#endif
 				InternalReplaceAt(index, value);
 				#if !DISABLE_EVENTS
-				ReplaceListEvent(index, value);
+				if (generateEvent) {
+					ReplaceListEvent(index, value);
+				}
 				#endif
 			}
 		}


### PR DESCRIPTION
* Removing a non-existent key or updating an existing key with the same value will no longer generate a delta
* Setting a primitive field to the same value will no longer generate a delta
* Replacing an element in a repeated field with the same value will no longer generate a delta.