### PR TITLE
Fixing issue with setting nested messages

### DIFF
--- a/proto/test/simple_message.proto
+++ b/proto/test/simple_message.proto
@@ -13,4 +13,10 @@ message ParentMessage {
 message ChildMessage {
   option (com.zynga.runtime.protobuf.event_sourced) = true;
   int64 c = 3;
+  ChildChildMessage d = 4;
+}
+
+message ChildChildMessage {
+  option (com.zynga.runtime.protobuf.event_sourced) = true;
+  int64 e = 5;
 }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/DeltaTests.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/DeltaTests.cs
@@ -555,6 +555,12 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 				// each event path should start with the number 16
 				Assert.Equal(16, e.Path[0]);
 			}
+
+			var blobB = new TestBlob();
+			blobB.ApplyEvents(snapshot);
+			blobB.ApplyEvents(events);
+
+			Assert.Equal(blob, blobB);
 		}
 	}
 }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/DeltaTests.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/DeltaTests.cs
@@ -502,5 +502,59 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 
 			AssertNotGenerated(blob);
 		}
+
+		[Fact]
+		public void ChangesToComplexChildMessageShouldHaveCorrectPath() {
+			var blob = populated();
+			var childBlob = populated();
+			blob.TestBlob_ = childBlob;
+
+			var snapshot = blob.GenerateSnapshot();
+
+			var blobA = new TestBlob();
+			blobA.ApplyEvents(snapshot);
+
+			Assert.Equal(blob, blobA);
+
+			blob.TestBlob_.Bar = new Bar();
+			blob.TestBlob_.Bar.Foo = new Foo();
+			blob.TestBlob_.Bar.Foo.Long = 10;
+			blob.TestBlob_.Bar.Foo.Str = "world";
+			blob.TestBlob_.Foo = new Foo();
+			blob.TestBlob_.Foo.Long = 12;
+			blob.TestBlob_.Foo.Str = "hello";
+
+			blob.TestBlob_.IntToString.Add(11, "world");
+			blob.TestBlob_.StringToFoo.Add("helloa", new Foo {Long = 9, Str = "ha"});
+			blob.TestBlob_.StringToFoo["helloa"].Str = "happy";
+			blob.TestBlob_.StringToFoo["helloa"].Long = 10;
+
+			blob.TestBlob_.Foolist.Add(new Foo {Long = 123});
+			blob.TestBlob_.Foolist[2].Long = 321;
+			blob.TestBlob_.Foolist.Add(new Foo {Long = 1, Str = "la", Foo_ = new Foo()});
+			blob.TestBlob_.Foolist[3].Str = "lalala";
+			blob.TestBlob_.Foolist[3].Long = 2;
+
+			blob.TestBlob_.Ilist.Add(12);
+			blob.TestBlob_.Ilist.Add(51);
+
+			blob.TestBlob_.Maybefoo = new Foo {Long = 42, Str = "maybe_foo_who_knows"};
+
+			blob.TestBlob_.Timestamp = new Timestamp {
+				Seconds = 1235,
+				Nanos = 987
+			};
+			blob.TestBlob_.Duration = new Duration {
+				Seconds = 112,
+				Nanos = 2
+			};
+
+			var events = blob.GenerateEvents();
+			foreach (var e in events.Events) {
+				// TestBlob test_blob = 16;
+				// each event path should start with the number 16
+				Assert.Equal(16, e.Path[0]);
+			}
+		}
 	}
 }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/SimpleMessageTests.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/SimpleMessageTests.cs
@@ -11,12 +11,30 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 			parent.B = childA;
 			var childB = new ChildMessage();
 			parent.B = childB;
-			
+
 			parent.ClearEvents();
 
 			// childA changes shouldn't generate events on the parent anymore
 			childA.C = 100;
 			AssertNotGenerated(parent);
+		}
+
+		[Fact]
+		public void ShouldGenerateEventsWithObjectIntializer() {
+			var a = new ChildMessage {D = new ChildChildMessage()};
+
+			var b = new ChildMessage {
+				D = new ChildChildMessage()
+			};
+
+			var parent = new ParentMessage {
+				B = b
+			};
+			AssertGenerated(parent);
+			parent.ClearEvents();
+
+			parent.B.D.E = 10;
+			AssertDeltaPath(parent, new int[]{2, 4, 5});
 		}
 	}
 }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
@@ -31,13 +31,16 @@ namespace Com.Zynga.Runtime.Protobuf {
             "Chl0ZXN0L3NpbXBsZV9tZXNzYWdlLnByb3RvEhpjb20uenluZ2EucnVudGlt",
             "ZS5wcm90b2J1ZhoSZXZlbnRfcGx1Z2luLnByb3RvIlsKDVBhcmVudE1lc3Nh",
             "Z2USDAoBYRgBIAEoBVIBYRI2CgFiGAIgASgLMiguY29tLnp5bmdhLnJ1bnRp",
-            "bWUucHJvdG9idWYuQ2hpbGRNZXNzYWdlUgFiOgTIuB4BIiIKDENoaWxkTWVz",
-            "c2FnZRIMCgFjGAMgASgDUgFjOgTIuB4BYgZwcm90bzM="));
+            "bWUucHJvdG9idWYuQ2hpbGRNZXNzYWdlUgFiOgTIuB4BIl8KDENoaWxkTWVz",
+            "c2FnZRIMCgFjGAMgASgDUgFjEjsKAWQYBCABKAsyLS5jb20uenluZ2EucnVu",
+            "dGltZS5wcm90b2J1Zi5DaGlsZENoaWxkTWVzc2FnZVIBZDoEyLgeASInChFD",
+            "aGlsZENoaWxkTWVzc2FnZRIMCgFlGAUgASgDUgFlOgTIuB4BYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Zynga.Protobuf.EventSource.EventPluginReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.ParentMessage), global::Com.Zynga.Runtime.Protobuf.ParentMessage.Parser, new[]{ "A", "B" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.ChildMessage), global::Com.Zynga.Runtime.Protobuf.ChildMessage.Parser, new[]{ "C" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.ChildMessage), global::Com.Zynga.Runtime.Protobuf.ChildMessage.Parser, new[]{ "C", "D" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.ChildChildMessage), global::Com.Zynga.Runtime.Protobuf.ChildChildMessage.Parser, new[]{ "E" }, null, null, null)
           }));
     }
     #endregion
@@ -279,6 +282,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public ChildMessage(ChildMessage other) : this() {
       c_ = other.c_;
+      d_ = other.d_ != null ? other.D.Clone() : null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -307,6 +311,24 @@ namespace Com.Zynga.Runtime.Protobuf {
       }
     }
 
+    /// <summary>Field number for the "d" field.</summary>
+    public const int DFieldNumber = 4;
+    private global::Com.Zynga.Runtime.Protobuf.ChildChildMessage d_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::Com.Zynga.Runtime.Protobuf.ChildChildMessage D {
+      get { return d_; }
+      set {
+        if(d_ != null) d_.ClearParent();
+        value.SetParent(Context, new EventPath(Context.Path, 4));
+        #if !DISABLE_EVENTS
+        if(value == null || !value.Equals(d_)) {
+          Context.AddSetEvent(4, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
+        #endif
+        d_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as ChildMessage);
@@ -321,6 +343,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         return true;
       }
       if (C != other.C) return false;
+      if (!object.Equals(D, other.D)) return false;
       return true;
     }
 
@@ -328,6 +351,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     public override int GetHashCode() {
       int hash = 1;
       if (C != 0L) hash ^= C.GetHashCode();
+      if (d_ != null) hash ^= D.GetHashCode();
       return hash;
     }
 
@@ -342,6 +366,10 @@ namespace Com.Zynga.Runtime.Protobuf {
         output.WriteRawTag(24);
         output.WriteInt64(C);
       }
+      if (d_ != null) {
+        output.WriteRawTag(34);
+        output.WriteMessage(D);
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -349,6 +377,9 @@ namespace Com.Zynga.Runtime.Protobuf {
       int size = 0;
       if (C != 0L) {
         size += 1 + pb::CodedOutputStream.ComputeInt64Size(C);
+      }
+      if (d_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(D);
       }
       return size;
     }
@@ -360,6 +391,12 @@ namespace Com.Zynga.Runtime.Protobuf {
       }
       if (other.C != 0L) {
         C = other.C;
+      }
+      if (other.d_ != null) {
+        if (d_ == null) {
+          d_ = new global::Com.Zynga.Runtime.Protobuf.ChildChildMessage();
+        }
+        D.MergeFrom(other.D);
       }
     }
 
@@ -375,6 +412,13 @@ namespace Com.Zynga.Runtime.Protobuf {
             C = input.ReadInt64();
             break;
           }
+          case 34: {
+            if (d_ == null) {
+              d_ = new global::Com.Zynga.Runtime.Protobuf.ChildChildMessage();
+            }
+            input.ReadMessage(d_);
+            break;
+          }
         }
       }
     }
@@ -387,6 +431,175 @@ namespace Com.Zynga.Runtime.Protobuf {
         switch (e.Path[pathIndex]) {
           case 3: {
             c_ = e.Set.I64;
+          }
+          break;
+          case 4: {
+            if (e.Path.Count - 1 != pathIndex) {
+              if (d_ == null) {
+                d_ = new global::Com.Zynga.Runtime.Protobuf.ChildChildMessage();
+                d_.SetParent(Context, new EventPath(Context.Path, 4));
+              }
+              (d_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+            } else {
+              d_  = global::Com.Zynga.Runtime.Protobuf.ChildChildMessage.Parser.ParseFrom(e.Set.ByteData);
+              d_.SetParent(Context, new EventPath(Context.Path, 4));
+            }
+          }
+          break;
+          default:
+            return false;
+          break;
+        }
+      return true;
+    }
+
+    public override zpr.EventSource.EventSourceRoot GenerateSnapshot() {
+      ClearEvents();
+      var er = new zpr.EventSource.EventSourceRoot();
+      var setEvent = new zpr.EventSource.EventData {
+        Set = new zpr.EventSource.EventContent {
+          ByteData = this.ToByteString()
+        }
+      };
+      er.Events.Add(setEvent);
+      return er;
+    }
+
+  }
+
+  public sealed partial class ChildChildMessage : zpr::EventRegistry, pb::IMessage<ChildChildMessage> {
+    private static readonly pb::MessageParser<ChildChildMessage> _parser = new pb::MessageParser<ChildChildMessage>(() => new ChildChildMessage());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<ChildChildMessage> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Com.Zynga.Runtime.Protobuf.SimpleMessageReflection.Descriptor.MessageTypes[2]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ChildChildMessage() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ChildChildMessage(ChildChildMessage other) : this() {
+      e_ = other.e_;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ChildChildMessage Clone() {
+      return new ChildChildMessage(this);
+    }
+
+    public static bool IsEventSourced = true;
+
+    public override void SetParent(EventContext parent, EventPath path) {
+      base.SetParent(parent, path);
+    }
+    /// <summary>Field number for the "e" field.</summary>
+    public const int EFieldNumber = 5;
+    private long e_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public long E {
+      get { return e_; }
+      set {
+        #if !DISABLE_EVENTS
+        if(e_ != value) {
+          Context.AddSetEvent(5, new zpr.EventSource.EventContent { I64 = value });
+        }
+        #endif
+        e_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as ChildChildMessage);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(ChildChildMessage other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (E != other.E) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (E != 0L) hash ^= E.GetHashCode();
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (E != 0L) {
+        output.WriteRawTag(40);
+        output.WriteInt64(E);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (E != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(E);
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(ChildChildMessage other) {
+      if (other == null) {
+        return;
+      }
+      if (other.E != 0L) {
+        E = other.E;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 40: {
+            E = input.ReadInt64();
+            break;
+          }
+        }
+      }
+    }
+
+    public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        if (e.Path.Count == 0) {
+          this.MergeFrom(e.Set.ByteData);
+          return true;
+        }
+        switch (e.Path[pathIndex]) {
+          case 5: {
+            e_ = e.Set.I64;
           }
           break;
           default:

--- a/runtime/src/Zynga.Protobuf.Runtime/EventContext.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventContext.cs
@@ -30,6 +30,11 @@ namespace Zynga.Protobuf.Runtime {
 			_path = path;
 			// when a message is added to a parent, any delta events it currently has are no longer valid
 			_events.Clear();
+
+			// update children paths
+			foreach (var child in _children) {
+				child.UpdatePath(_path);
+			}
 		}
 
 		/// <summary>
@@ -39,6 +44,11 @@ namespace Zynga.Protobuf.Runtime {
 			_parent?.RemoveChild(this);
 			_parent = null;
 			_path = EventPath.Empty;
+
+			// update children paths
+			foreach (var child in _children) {
+				child.UpdatePath(_path);
+			}
 		}
 
 		/// <summary>
@@ -60,6 +70,13 @@ namespace Zynga.Protobuf.Runtime {
 		/// </summary>
 		public void ClearEvents() {
 			_events.Clear();
+		}
+
+		/// <summary>
+		/// Updates the path based on the parent path
+		/// </summary>
+		public void UpdatePath(EventPath parentPath) {
+			_path = new EventPath(parentPath, _path.Path[_path.Path.Count - 1]);
 		}
 
 		/// <summary>


### PR DESCRIPTION
When setting a message that already has children set, it could result in invalid paths being created.   This fix ensures that paths are updated when a new parent is set.