### PR TITLE
Fixing deltas of elements in a map or list

### DIFF
--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/DeltaTests.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/DeltaTests.cs
@@ -193,16 +193,6 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 		}
 
 		[Fact]
-		public void ShouldProduceIdenticalTestBlobWithMergeFrom() {
-			var blob = populated();
-
-			var newBlob = new TestBlob();
-			newBlob.MergeFrom(blob);
-			Assert.Equal(blob, newBlob);
-			Assert.Equal(newBlob, blob);
-		}
-
-		[Fact]
 		public void ShouldNotGenerateDeltasForNoOpsOnMaps() {
 			var blob = new TestBlob();
 			blob.IntToString[0] = "a";

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/FileTests.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/FileTests.cs
@@ -193,16 +193,6 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 		}
 
 		[Fact]
-		public void ShouldProduceIdenticalTestBlobWithMergeFrom() {
-			var blob = populated();
-
-			var newBlob = new TestBlob();
-			newBlob.MergeFrom(blob);
-			Assert.Equal(blob, newBlob);
-			Assert.Equal(newBlob, blob);
-		}
-
-		[Fact]
 		public void ShouldNotGenerateDeltasForNoOpsOnMaps() {
 			var blob = new TestBlob();
 			blob.IntToString[0] = "a";

--- a/runtime/src/Zynga.Protobuf.Runtime/EventMapField.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventMapField.cs
@@ -48,18 +48,10 @@ namespace Zynga.Protobuf.Runtime {
 
 		public void Add(EventMapField<TKey, TValue> other) {
 			foreach (var kv in other) {
-				if (kv.Value is IDeepCloneable<TValue>) {
-					InternalAdd(kv.Key, ((IDeepCloneable<TValue>) kv.Value).Clone());
-					#if !DISABLE_EVENTS
-					AddMapEvent(kv.Key, kv.Value);
-					#endif
-				}
-				else {
-					InternalAdd(kv.Key, kv.Value);
-					#if !DISABLE_EVENTS
-					AddMapEvent(kv.Key, kv.Value);
-					#endif
-				}
+				InternalAdd(kv.Key, kv.Value);
+				#if !DISABLE_EVENTS
+				AddMapEvent(kv.Key, kv.Value);
+				#endif
 			}
 		}
 

--- a/runtime/src/Zynga.Protobuf.Runtime/EventRepeatedField.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventRepeatedField.cs
@@ -68,35 +68,19 @@ namespace Zynga.Protobuf.Runtime {
 
 		public void Add(EventRepeatedField<T> other) {
 			foreach (var v in other) {
-				if (v is IDeepCloneable<T>) {
-					InternalAdd(((IDeepCloneable<T>) v).Clone());
-					#if !DISABLE_EVENTS
-					AddListEvent(v);
-					#endif
-				}
-				else {
-					InternalAdd(v);
-					#if !DISABLE_EVENTS
-					AddListEvent(v);
-					#endif
-				}
+				InternalAdd(v);
+				#if !DISABLE_EVENTS
+				AddListEvent(v);
+				#endif
 			}
 		}
 
 		public void Add(IList<T> other) {
 			foreach (var v in other) {
-				if (v is IDeepCloneable<T>) {
-					InternalAdd(((IDeepCloneable<T>) v).Clone());
-					#if !DISABLE_EVENTS
-					AddListEvent(v);
-					#endif
-				}
-				else {
-					InternalAdd(v);
-					#if !DISABLE_EVENTS
-					AddListEvent(v);
-					#endif
-				}
+				InternalAdd(v);
+				#if !DISABLE_EVENTS
+				AddListEvent(v);
+				#endif
 			}
 		}
 


### PR DESCRIPTION
To allow MergeFrom to work, if the map or list type was a message, we were cloning it.  This clone can actually cause issues when normally adding one or many items to a map or list, as the original reference if it wasn't part of a parent message, can no longer be used to make changes.  Removing the clone for now.