### PR TITLE
Fix message parentage when applying a snapshot

### DIFF
--- a/plugin/src/lib/csharp_message_field.cc
+++ b/plugin/src/lib/csharp_message_field.cc
@@ -176,7 +176,7 @@ void MessageFieldGenerator::GenerateMergingCode(io::Printer* printer) {
     "  $property_name$.MergeFrom(other.$property_name$);\n");
   if(isEventSourced) {
     printer->Print(variables_,
-      "$property_name$.SetParent(Context, new EventPath(Context.Path, $number$));\n");
+      "  $property_name$.SetParent(Context, new EventPath(Context.Path, $number$));\n");
   }
   printer->Print(
     variables_,

--- a/plugin/src/lib/csharp_message_field.cc
+++ b/plugin/src/lib/csharp_message_field.cc
@@ -166,17 +166,25 @@ void MessageFieldGenerator::GenerateCheckSum(io::Printer* printer) {
 
 
 void MessageFieldGenerator::GenerateMergingCode(io::Printer* printer) {
+  bool isEventSourced = IsInternalEventSourced();
   printer->Print(
     variables_,
     "if (other.$has_property_check$) {\n"
     "  if ($has_not_property_check$) {\n"
     "    $name$_ = new $type_name$();\n"
     "  }\n"
-    "  $property_name$.MergeFrom(other.$property_name$);\n"
+    "  $property_name$.MergeFrom(other.$property_name$);\n");
+  if(isEventSourced) {
+    printer->Print(variables_,
+      "$property_name$.SetParent(Context, new EventPath(Context.Path, $number$));\n");
+  }
+  printer->Print(
+    variables_,
     "}\n");
 }
 
 void MessageFieldGenerator::GenerateParsingCode(io::Printer* printer) {
+  bool isEventSourced = IsInternalEventSourced();
   printer->Print(
     variables_,
     "if ($has_not_property_check$) {\n"
@@ -184,7 +192,12 @@ void MessageFieldGenerator::GenerateParsingCode(io::Printer* printer) {
     "}\n"
     // TODO(jonskeet): Do we really need merging behaviour like this?
     "input.ReadMessage($name$_);\n"); // No need to support TYPE_GROUP...
+  if(isEventSourced) {
+    printer->Print(variables_,
+      "$property_name$.SetParent(Context, new EventPath(Context.Path, $number$));\n");
+  }
 }
+
 
 void MessageFieldGenerator::GenerateSerializationCode(io::Printer* printer) {
   printer->Print(
@@ -368,11 +381,16 @@ void MessageOneofFieldGenerator::GenerateEventAddEvent(io::Printer* printer) {
 }
 
 void MessageOneofFieldGenerator::GenerateMergingCode(io::Printer* printer) {
+  bool isEventSourced = IsInternalEventSourced();
   printer->Print(variables_, 
     "if ($property_name$ == null) {\n"
     "  $property_name$ = new $type_name$();\n"
     "}\n"
     "$property_name$.MergeFrom(other.$property_name$);\n");
+  if(isEventSourced) {
+    printer->Print(variables_,
+      "$property_name$.SetParent(Context, new EventPath(Context.Path, $number$));\n");
+  }
 }
 
 void MessageOneofFieldGenerator::GenerateParsingCode(io::Printer* printer) {

--- a/proto/test/complex_test.proto
+++ b/proto/test/complex_test.proto
@@ -91,3 +91,41 @@ message MessageG {
   int32 m = 5;
   int32 n = 6;
 }
+
+// List Test
+
+message MessageO {
+  MessageP p = 8;
+
+  // ensure all numeric ids are in each message
+  int32 t = 9;
+  int32 u = 10;
+  int32 v = 11;
+}
+
+message MessageP {
+  MessageQ q = 9;
+
+  // ensure all numeric ids are in each message
+  int32 s = 8;
+  int32 u = 10;
+  int32 v = 11;
+}
+
+message MessageQ {
+ repeated MessageR r = 10;
+
+  // ensure all numeric ids are in each message
+  int32 s = 8;
+  int32 t = 9;
+  int32 v = 11;
+}
+
+message MessageR {
+  string r = 11;
+
+  // ensure all numeric ids are in each message
+  int32 s = 8;
+  int32 t = 9;
+  int32 u = 10;
+}

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/ComplexTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/ComplexTest.cs
@@ -57,7 +57,16 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             "KAVSAWsSDAoBbBgEIAEoBVIBbBIMCgFtGAUgASgFUgFtEgwKAW8YByABKAVS",
             "AW8ibAoITWVzc2FnZUcSDAoBaBgHIAMoBVIBaBIMCgFpGAEgASgFUgFpEgwK",
             "AWoYAiABKAVSAWoSDAoBaxgDIAEoBVIBaxIMCgFsGAQgASgFUgFsEgwKAW0Y",
-            "BSABKAVSAW0SDAoBbhgGIAEoBVIBbkIE2LgeAWIGcHJvdG8z"));
+            "BSABKAVSAW0SDAoBbhgGIAEoBVIBbiJtCghNZXNzYWdlTxI3CgFwGAggASgL",
+            "MikuY29tLnp5bmdhLnJ1bnRpbWUucHJvdG9idWYuZmlsZS5NZXNzYWdlUFIB",
+            "cBIMCgF0GAkgASgFUgF0EgwKAXUYCiABKAVSAXUSDAoBdhgLIAEoBVIBdiJt",
+            "CghNZXNzYWdlUBI3CgFxGAkgASgLMikuY29tLnp5bmdhLnJ1bnRpbWUucHJv",
+            "dG9idWYuZmlsZS5NZXNzYWdlUVIBcRIMCgFzGAggASgFUgFzEgwKAXUYCiAB",
+            "KAVSAXUSDAoBdhgLIAEoBVIBdiJtCghNZXNzYWdlURI3CgFyGAogAygLMiku",
+            "Y29tLnp5bmdhLnJ1bnRpbWUucHJvdG9idWYuZmlsZS5NZXNzYWdlUlIBchIM",
+            "CgFzGAggASgFUgFzEgwKAXQYCSABKAVSAXQSDAoBdhgLIAEoBVIBdiJCCghN",
+            "ZXNzYWdlUhIMCgFyGAsgASgJUgFyEgwKAXMYCCABKAVSAXMSDAoBdBgJIAEo",
+            "BVIBdBIMCgF1GAogASgFUgF1QgTYuB4BYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Zynga.Protobuf.EventSource.EventPluginReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
@@ -67,7 +76,11 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.File.MessageD), global::Com.Zynga.Runtime.Protobuf.File.MessageD.Parser, new[]{ "E", "I", "J", "K", "M", "N", "O" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.File.MessageE), global::Com.Zynga.Runtime.Protobuf.File.MessageE.Parser, new[]{ "F", "I", "J", "K", "L", "N", "O" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.File.MessageF), global::Com.Zynga.Runtime.Protobuf.File.MessageF.Parser, new[]{ "G", "I", "J", "K", "L", "M", "O" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.File.MessageG), global::Com.Zynga.Runtime.Protobuf.File.MessageG.Parser, new[]{ "H", "I", "J", "K", "L", "M", "N" }, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.File.MessageG), global::Com.Zynga.Runtime.Protobuf.File.MessageG.Parser, new[]{ "H", "I", "J", "K", "L", "M", "N" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.File.MessageO), global::Com.Zynga.Runtime.Protobuf.File.MessageO.Parser, new[]{ "P", "T", "U", "V" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.File.MessageP), global::Com.Zynga.Runtime.Protobuf.File.MessageP.Parser, new[]{ "Q", "S", "U", "V" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.File.MessageQ), global::Com.Zynga.Runtime.Protobuf.File.MessageQ.Parser, new[]{ "R", "S", "T", "V" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.File.MessageR), global::Com.Zynga.Runtime.Protobuf.File.MessageR.Parser, new[]{ "R", "S", "T", "U" }, null, null, null)
           }));
     }
     #endregion
@@ -2844,6 +2857,1120 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           break;
           case 6: {
             n_ = e.Set.I32;
+          }
+          break;
+          default:
+            return false;
+          break;
+        }
+      return true;
+    }
+
+    public override zpr.EventSource.EventSourceRoot GenerateSnapshot() {
+      ClearEvents();
+      var er = new zpr.EventSource.EventSourceRoot();
+      var setEvent = new zpr.EventSource.EventData {
+        Set = new zpr.EventSource.EventContent {
+          ByteData = this.ToByteString()
+        }
+      };
+      er.Events.Add(setEvent);
+      return er;
+    }
+
+  }
+
+  public sealed partial class MessageO : zpr::EventRegistry, pb::IMessage<MessageO> {
+    private static readonly pb::MessageParser<MessageO> _parser = new pb::MessageParser<MessageO>(() => new MessageO());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<MessageO> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Com.Zynga.Runtime.Protobuf.File.ComplexTestReflection.Descriptor.MessageTypes[7]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MessageO() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MessageO(MessageO other) : this() {
+      p_ = other.p_ != null ? other.P.Clone() : null;
+      t_ = other.t_;
+      u_ = other.u_;
+      v_ = other.v_;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MessageO Clone() {
+      return new MessageO(this);
+    }
+
+    public static bool IsEventSourced = true;
+
+    public override void SetParent(EventContext parent, EventPath path) {
+      base.SetParent(parent, path);
+    }
+    /// <summary>Field number for the "p" field.</summary>
+    public const int PFieldNumber = 8;
+    private global::Com.Zynga.Runtime.Protobuf.File.MessageP p_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::Com.Zynga.Runtime.Protobuf.File.MessageP P {
+      get { return p_; }
+      set {
+        if(p_ != null) p_.ClearParent();
+        value.SetParent(Context, new EventPath(Context.Path, 8));
+        #if !DISABLE_EVENTS
+        if(value == null || !value.Equals(p_)) {
+          Context.AddSetEvent(8, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
+        #endif
+        p_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "t" field.</summary>
+    public const int TFieldNumber = 9;
+    private int t_;
+    /// <summary>
+    /// ensure all numeric ids are in each message
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int T {
+      get { return t_; }
+      set {
+        #if !DISABLE_EVENTS
+        if(t_ != value) {
+          Context.AddSetEvent(9, new zpr.EventSource.EventContent { I32 = value });
+        }
+        #endif
+        t_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "u" field.</summary>
+    public const int UFieldNumber = 10;
+    private int u_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int U {
+      get { return u_; }
+      set {
+        #if !DISABLE_EVENTS
+        if(u_ != value) {
+          Context.AddSetEvent(10, new zpr.EventSource.EventContent { I32 = value });
+        }
+        #endif
+        u_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "v" field.</summary>
+    public const int VFieldNumber = 11;
+    private int v_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int V {
+      get { return v_; }
+      set {
+        #if !DISABLE_EVENTS
+        if(v_ != value) {
+          Context.AddSetEvent(11, new zpr.EventSource.EventContent { I32 = value });
+        }
+        #endif
+        v_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as MessageO);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(MessageO other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (!object.Equals(P, other.P)) return false;
+      if (T != other.T) return false;
+      if (U != other.U) return false;
+      if (V != other.V) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (p_ != null) hash ^= P.GetHashCode();
+      if (T != 0) hash ^= T.GetHashCode();
+      if (U != 0) hash ^= U.GetHashCode();
+      if (V != 0) hash ^= V.GetHashCode();
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (p_ != null) {
+        output.WriteRawTag(66);
+        output.WriteMessage(P);
+      }
+      if (T != 0) {
+        output.WriteRawTag(72);
+        output.WriteInt32(T);
+      }
+      if (U != 0) {
+        output.WriteRawTag(80);
+        output.WriteInt32(U);
+      }
+      if (V != 0) {
+        output.WriteRawTag(88);
+        output.WriteInt32(V);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (p_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(P);
+      }
+      if (T != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(T);
+      }
+      if (U != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(U);
+      }
+      if (V != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(V);
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(MessageO other) {
+      if (other == null) {
+        return;
+      }
+      if (other.p_ != null) {
+        if (p_ == null) {
+          p_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageP();
+        }
+        P.MergeFrom(other.P);
+      }
+      if (other.T != 0) {
+        T = other.T;
+      }
+      if (other.U != 0) {
+        U = other.U;
+      }
+      if (other.V != 0) {
+        V = other.V;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 66: {
+            if (p_ == null) {
+              p_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageP();
+            }
+            input.ReadMessage(p_);
+            break;
+          }
+          case 72: {
+            T = input.ReadInt32();
+            break;
+          }
+          case 80: {
+            U = input.ReadInt32();
+            break;
+          }
+          case 88: {
+            V = input.ReadInt32();
+            break;
+          }
+        }
+      }
+    }
+
+    public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        if (e.Path.Count == 0) {
+          this.MergeFrom(e.Set.ByteData);
+          return true;
+        }
+        switch (e.Path[pathIndex]) {
+          case 8: {
+            if (e.Path.Count - 1 != pathIndex) {
+              if (p_ == null) {
+                p_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageP();
+                p_.SetParent(Context, new EventPath(Context.Path, 8));
+              }
+              (p_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+            } else {
+              p_  = global::Com.Zynga.Runtime.Protobuf.File.MessageP.Parser.ParseFrom(e.Set.ByteData);
+              p_.SetParent(Context, new EventPath(Context.Path, 8));
+            }
+          }
+          break;
+          case 9: {
+            t_ = e.Set.I32;
+          }
+          break;
+          case 10: {
+            u_ = e.Set.I32;
+          }
+          break;
+          case 11: {
+            v_ = e.Set.I32;
+          }
+          break;
+          default:
+            return false;
+          break;
+        }
+      return true;
+    }
+
+    public override zpr.EventSource.EventSourceRoot GenerateSnapshot() {
+      ClearEvents();
+      var er = new zpr.EventSource.EventSourceRoot();
+      var setEvent = new zpr.EventSource.EventData {
+        Set = new zpr.EventSource.EventContent {
+          ByteData = this.ToByteString()
+        }
+      };
+      er.Events.Add(setEvent);
+      return er;
+    }
+
+  }
+
+  public sealed partial class MessageP : zpr::EventRegistry, pb::IMessage<MessageP> {
+    private static readonly pb::MessageParser<MessageP> _parser = new pb::MessageParser<MessageP>(() => new MessageP());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<MessageP> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Com.Zynga.Runtime.Protobuf.File.ComplexTestReflection.Descriptor.MessageTypes[8]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MessageP() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MessageP(MessageP other) : this() {
+      q_ = other.q_ != null ? other.Q.Clone() : null;
+      s_ = other.s_;
+      u_ = other.u_;
+      v_ = other.v_;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MessageP Clone() {
+      return new MessageP(this);
+    }
+
+    public static bool IsEventSourced = true;
+
+    public override void SetParent(EventContext parent, EventPath path) {
+      base.SetParent(parent, path);
+    }
+    /// <summary>Field number for the "q" field.</summary>
+    public const int QFieldNumber = 9;
+    private global::Com.Zynga.Runtime.Protobuf.File.MessageQ q_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::Com.Zynga.Runtime.Protobuf.File.MessageQ Q {
+      get { return q_; }
+      set {
+        if(q_ != null) q_.ClearParent();
+        value.SetParent(Context, new EventPath(Context.Path, 9));
+        #if !DISABLE_EVENTS
+        if(value == null || !value.Equals(q_)) {
+          Context.AddSetEvent(9, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
+        }
+        #endif
+        q_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "s" field.</summary>
+    public const int SFieldNumber = 8;
+    private int s_;
+    /// <summary>
+    /// ensure all numeric ids are in each message
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int S {
+      get { return s_; }
+      set {
+        #if !DISABLE_EVENTS
+        if(s_ != value) {
+          Context.AddSetEvent(8, new zpr.EventSource.EventContent { I32 = value });
+        }
+        #endif
+        s_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "u" field.</summary>
+    public const int UFieldNumber = 10;
+    private int u_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int U {
+      get { return u_; }
+      set {
+        #if !DISABLE_EVENTS
+        if(u_ != value) {
+          Context.AddSetEvent(10, new zpr.EventSource.EventContent { I32 = value });
+        }
+        #endif
+        u_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "v" field.</summary>
+    public const int VFieldNumber = 11;
+    private int v_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int V {
+      get { return v_; }
+      set {
+        #if !DISABLE_EVENTS
+        if(v_ != value) {
+          Context.AddSetEvent(11, new zpr.EventSource.EventContent { I32 = value });
+        }
+        #endif
+        v_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as MessageP);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(MessageP other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (!object.Equals(Q, other.Q)) return false;
+      if (S != other.S) return false;
+      if (U != other.U) return false;
+      if (V != other.V) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (q_ != null) hash ^= Q.GetHashCode();
+      if (S != 0) hash ^= S.GetHashCode();
+      if (U != 0) hash ^= U.GetHashCode();
+      if (V != 0) hash ^= V.GetHashCode();
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (S != 0) {
+        output.WriteRawTag(64);
+        output.WriteInt32(S);
+      }
+      if (q_ != null) {
+        output.WriteRawTag(74);
+        output.WriteMessage(Q);
+      }
+      if (U != 0) {
+        output.WriteRawTag(80);
+        output.WriteInt32(U);
+      }
+      if (V != 0) {
+        output.WriteRawTag(88);
+        output.WriteInt32(V);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (q_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Q);
+      }
+      if (S != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(S);
+      }
+      if (U != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(U);
+      }
+      if (V != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(V);
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(MessageP other) {
+      if (other == null) {
+        return;
+      }
+      if (other.q_ != null) {
+        if (q_ == null) {
+          q_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageQ();
+        }
+        Q.MergeFrom(other.Q);
+      }
+      if (other.S != 0) {
+        S = other.S;
+      }
+      if (other.U != 0) {
+        U = other.U;
+      }
+      if (other.V != 0) {
+        V = other.V;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 64: {
+            S = input.ReadInt32();
+            break;
+          }
+          case 74: {
+            if (q_ == null) {
+              q_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageQ();
+            }
+            input.ReadMessage(q_);
+            break;
+          }
+          case 80: {
+            U = input.ReadInt32();
+            break;
+          }
+          case 88: {
+            V = input.ReadInt32();
+            break;
+          }
+        }
+      }
+    }
+
+    public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        if (e.Path.Count == 0) {
+          this.MergeFrom(e.Set.ByteData);
+          return true;
+        }
+        switch (e.Path[pathIndex]) {
+          case 9: {
+            if (e.Path.Count - 1 != pathIndex) {
+              if (q_ == null) {
+                q_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageQ();
+                q_.SetParent(Context, new EventPath(Context.Path, 9));
+              }
+              (q_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+            } else {
+              q_  = global::Com.Zynga.Runtime.Protobuf.File.MessageQ.Parser.ParseFrom(e.Set.ByteData);
+              q_.SetParent(Context, new EventPath(Context.Path, 9));
+            }
+          }
+          break;
+          case 8: {
+            s_ = e.Set.I32;
+          }
+          break;
+          case 10: {
+            u_ = e.Set.I32;
+          }
+          break;
+          case 11: {
+            v_ = e.Set.I32;
+          }
+          break;
+          default:
+            return false;
+          break;
+        }
+      return true;
+    }
+
+    public override zpr.EventSource.EventSourceRoot GenerateSnapshot() {
+      ClearEvents();
+      var er = new zpr.EventSource.EventSourceRoot();
+      var setEvent = new zpr.EventSource.EventData {
+        Set = new zpr.EventSource.EventContent {
+          ByteData = this.ToByteString()
+        }
+      };
+      er.Events.Add(setEvent);
+      return er;
+    }
+
+  }
+
+  public sealed partial class MessageQ : zpr::EventRegistry, pb::IMessage<MessageQ> {
+    private static readonly pb::MessageParser<MessageQ> _parser = new pb::MessageParser<MessageQ>(() => new MessageQ());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<MessageQ> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Com.Zynga.Runtime.Protobuf.File.ComplexTestReflection.Descriptor.MessageTypes[9]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MessageQ() {
+      OnConstruction();
+      r_.SetContext(Context, 10);
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MessageQ(MessageQ other) : this() {
+      r_ = new EventRepeatedField<global::Com.Zynga.Runtime.Protobuf.File.MessageR>(rDataConverter, other.R.Clone(), true);
+      r_.SetContext(Context, 10);
+      s_ = other.s_;
+      t_ = other.t_;
+      v_ = other.v_;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MessageQ Clone() {
+      return new MessageQ(this);
+    }
+
+    public static bool IsEventSourced = true;
+
+    public override void SetParent(EventContext parent, EventPath path) {
+      base.SetParent(parent, path);
+      r_.SetContext(Context, 10);
+    }
+    /// <summary>Field number for the "r" field.</summary>
+    public const int RFieldNumber = 10;
+    private static readonly pb::FieldCodec<global::Com.Zynga.Runtime.Protobuf.File.MessageR> _repeated_r_codec
+        = pb::FieldCodec.ForMessage(82, global::Com.Zynga.Runtime.Protobuf.File.MessageR.Parser);
+    public class RDataConverter: EventDataConverter<global::Com.Zynga.Runtime.Protobuf.File.MessageR> {
+      public override zpr.EventSource.EventContent GetEventData(global::Com.Zynga.Runtime.Protobuf.File.MessageR data) {
+        var byteData = (data as pb::IMessage)?.ToByteString();
+        return new zpr.EventSource.EventContent() { ByteData = byteData };
+      }
+      public override global::Com.Zynga.Runtime.Protobuf.File.MessageR GetItem(zpr.EventSource.EventContent data) {
+        return global::Com.Zynga.Runtime.Protobuf.File.MessageR.Parser.ParseFrom(data.ByteData);
+      }
+    }
+    private static RDataConverter rDataConverter = new RDataConverter();
+    private readonly EventRepeatedField<global::Com.Zynga.Runtime.Protobuf.File.MessageR> r_ = new EventRepeatedField<global::Com.Zynga.Runtime.Protobuf.File.MessageR>(rDataConverter, true);
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public EventRepeatedField<global::Com.Zynga.Runtime.Protobuf.File.MessageR> R {
+      get { return r_; }
+    }
+
+    /// <summary>Field number for the "s" field.</summary>
+    public const int SFieldNumber = 8;
+    private int s_;
+    /// <summary>
+    /// ensure all numeric ids are in each message
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int S {
+      get { return s_; }
+      set {
+        #if !DISABLE_EVENTS
+        if(s_ != value) {
+          Context.AddSetEvent(8, new zpr.EventSource.EventContent { I32 = value });
+        }
+        #endif
+        s_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "t" field.</summary>
+    public const int TFieldNumber = 9;
+    private int t_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int T {
+      get { return t_; }
+      set {
+        #if !DISABLE_EVENTS
+        if(t_ != value) {
+          Context.AddSetEvent(9, new zpr.EventSource.EventContent { I32 = value });
+        }
+        #endif
+        t_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "v" field.</summary>
+    public const int VFieldNumber = 11;
+    private int v_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int V {
+      get { return v_; }
+      set {
+        #if !DISABLE_EVENTS
+        if(v_ != value) {
+          Context.AddSetEvent(11, new zpr.EventSource.EventContent { I32 = value });
+        }
+        #endif
+        v_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as MessageQ);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(MessageQ other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if(!r_.Equals(other.r_)) return false;
+      if (S != other.S) return false;
+      if (T != other.T) return false;
+      if (V != other.V) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      hash ^= r_.GetHashCode();
+      if (S != 0) hash ^= S.GetHashCode();
+      if (T != 0) hash ^= T.GetHashCode();
+      if (V != 0) hash ^= V.GetHashCode();
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (S != 0) {
+        output.WriteRawTag(64);
+        output.WriteInt32(S);
+      }
+      if (T != 0) {
+        output.WriteRawTag(72);
+        output.WriteInt32(T);
+      }
+      r_.WriteTo(output, _repeated_r_codec);
+      if (V != 0) {
+        output.WriteRawTag(88);
+        output.WriteInt32(V);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      size += r_.CalculateSize(_repeated_r_codec);
+      if (S != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(S);
+      }
+      if (T != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(T);
+      }
+      if (V != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(V);
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(MessageQ other) {
+      if (other == null) {
+        return;
+      }
+      r_.Add(other.r_);
+      if (other.S != 0) {
+        S = other.S;
+      }
+      if (other.T != 0) {
+        T = other.T;
+      }
+      if (other.V != 0) {
+        V = other.V;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 64: {
+            S = input.ReadInt32();
+            break;
+          }
+          case 72: {
+            T = input.ReadInt32();
+            break;
+          }
+          case 82: {
+            r_.AddEntriesFrom(input, _repeated_r_codec);
+            break;
+          }
+          case 88: {
+            V = input.ReadInt32();
+            break;
+          }
+        }
+      }
+    }
+
+    public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        if (e.Path.Count == 0) {
+          this.MergeFrom(e.Set.ByteData);
+          return true;
+        }
+        switch (e.Path[pathIndex]) {
+          case 10: {
+            r_.ApplyEvent(e.ListEvent);
+          }
+          break;
+          case 8: {
+            s_ = e.Set.I32;
+          }
+          break;
+          case 9: {
+            t_ = e.Set.I32;
+          }
+          break;
+          case 11: {
+            v_ = e.Set.I32;
+          }
+          break;
+          default:
+            return false;
+          break;
+        }
+      return true;
+    }
+
+    public override zpr.EventSource.EventSourceRoot GenerateSnapshot() {
+      ClearEvents();
+      var er = new zpr.EventSource.EventSourceRoot();
+      var setEvent = new zpr.EventSource.EventData {
+        Set = new zpr.EventSource.EventContent {
+          ByteData = this.ToByteString()
+        }
+      };
+      er.Events.Add(setEvent);
+      return er;
+    }
+
+  }
+
+  public sealed partial class MessageR : zpr::EventRegistry, pb::IMessage<MessageR> {
+    private static readonly pb::MessageParser<MessageR> _parser = new pb::MessageParser<MessageR>(() => new MessageR());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<MessageR> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Com.Zynga.Runtime.Protobuf.File.ComplexTestReflection.Descriptor.MessageTypes[10]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MessageR() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MessageR(MessageR other) : this() {
+      r_ = other.r_;
+      s_ = other.s_;
+      t_ = other.t_;
+      u_ = other.u_;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MessageR Clone() {
+      return new MessageR(this);
+    }
+
+    public static bool IsEventSourced = true;
+
+    public override void SetParent(EventContext parent, EventPath path) {
+      base.SetParent(parent, path);
+    }
+    /// <summary>Field number for the "r" field.</summary>
+    public const int RFieldNumber = 11;
+    private string r_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string R {
+      get { return r_; }
+      set {
+        #if !DISABLE_EVENTS
+        if(r_ != value) {
+          Context.AddSetEvent(11, new zpr.EventSource.EventContent { StringData = pb::ProtoPreconditions.CheckNotNull(value, "value") });
+        }
+        #endif
+        r_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "s" field.</summary>
+    public const int SFieldNumber = 8;
+    private int s_;
+    /// <summary>
+    /// ensure all numeric ids are in each message
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int S {
+      get { return s_; }
+      set {
+        #if !DISABLE_EVENTS
+        if(s_ != value) {
+          Context.AddSetEvent(8, new zpr.EventSource.EventContent { I32 = value });
+        }
+        #endif
+        s_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "t" field.</summary>
+    public const int TFieldNumber = 9;
+    private int t_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int T {
+      get { return t_; }
+      set {
+        #if !DISABLE_EVENTS
+        if(t_ != value) {
+          Context.AddSetEvent(9, new zpr.EventSource.EventContent { I32 = value });
+        }
+        #endif
+        t_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "u" field.</summary>
+    public const int UFieldNumber = 10;
+    private int u_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int U {
+      get { return u_; }
+      set {
+        #if !DISABLE_EVENTS
+        if(u_ != value) {
+          Context.AddSetEvent(10, new zpr.EventSource.EventContent { I32 = value });
+        }
+        #endif
+        u_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as MessageR);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(MessageR other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (R != other.R) return false;
+      if (S != other.S) return false;
+      if (T != other.T) return false;
+      if (U != other.U) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (R.Length != 0) hash ^= R.GetHashCode();
+      if (S != 0) hash ^= S.GetHashCode();
+      if (T != 0) hash ^= T.GetHashCode();
+      if (U != 0) hash ^= U.GetHashCode();
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (S != 0) {
+        output.WriteRawTag(64);
+        output.WriteInt32(S);
+      }
+      if (T != 0) {
+        output.WriteRawTag(72);
+        output.WriteInt32(T);
+      }
+      if (U != 0) {
+        output.WriteRawTag(80);
+        output.WriteInt32(U);
+      }
+      if (R.Length != 0) {
+        output.WriteRawTag(90);
+        output.WriteString(R);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (R.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(R);
+      }
+      if (S != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(S);
+      }
+      if (T != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(T);
+      }
+      if (U != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(U);
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(MessageR other) {
+      if (other == null) {
+        return;
+      }
+      if (other.R.Length != 0) {
+        R = other.R;
+      }
+      if (other.S != 0) {
+        S = other.S;
+      }
+      if (other.T != 0) {
+        T = other.T;
+      }
+      if (other.U != 0) {
+        U = other.U;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 64: {
+            S = input.ReadInt32();
+            break;
+          }
+          case 72: {
+            T = input.ReadInt32();
+            break;
+          }
+          case 80: {
+            U = input.ReadInt32();
+            break;
+          }
+          case 90: {
+            R = input.ReadString();
+            break;
+          }
+        }
+      }
+    }
+
+    public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        if (e.Path.Count == 0) {
+          this.MergeFrom(e.Set.ByteData);
+          return true;
+        }
+        switch (e.Path[pathIndex]) {
+          case 11: {
+            r_ = e.Set.StringData;
+          }
+          break;
+          case 8: {
+            s_ = e.Set.I32;
+          }
+          break;
+          case 9: {
+            t_ = e.Set.I32;
+          }
+          break;
+          case 10: {
+            u_ = e.Set.I32;
           }
           break;
           default:

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/ComplexTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/ComplexTest.cs
@@ -1576,7 +1576,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           e_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageE();
         }
         E.MergeFrom(other.E);
-      E.SetParent(Context, new EventPath(Context.Path, 4));
+        E.SetParent(Context, new EventPath(Context.Path, 4));
       }
       if (other.I != 0) {
         I = other.I;
@@ -1976,7 +1976,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           f_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageF();
         }
         F.MergeFrom(other.F);
-      F.SetParent(Context, new EventPath(Context.Path, 5));
+        F.SetParent(Context, new EventPath(Context.Path, 5));
       }
       if (other.I != 0) {
         I = other.I;
@@ -2376,7 +2376,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           g_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageG();
         }
         G.MergeFrom(other.G);
-      G.SetParent(Context, new EventPath(Context.Path, 6));
+        G.SetParent(Context, new EventPath(Context.Path, 6));
       }
       if (other.I != 0) {
         I = other.I;
@@ -3079,7 +3079,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           p_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageP();
         }
         P.MergeFrom(other.P);
-      P.SetParent(Context, new EventPath(Context.Path, 8));
+        P.SetParent(Context, new EventPath(Context.Path, 8));
       }
       if (other.T != 0) {
         T = other.T;
@@ -3368,7 +3368,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           q_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageQ();
         }
         Q.MergeFrom(other.Q);
-      Q.SetParent(Context, new EventPath(Context.Path, 9));
+        Q.SetParent(Context, new EventPath(Context.Path, 9));
       }
       if (other.S != 0) {
         S = other.S;

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/ComplexTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/ComplexTest.cs
@@ -400,6 +400,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             B = new global::Com.Zynga.Runtime.Protobuf.File.MessageB();
           }
           B.MergeFrom(other.B);
+          B.SetParent(Context, new EventPath(Context.Path, 1));
           break;
       }
 
@@ -1575,6 +1576,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           e_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageE();
         }
         E.MergeFrom(other.E);
+      E.SetParent(Context, new EventPath(Context.Path, 4));
       }
       if (other.I != 0) {
         I = other.I;
@@ -1621,6 +1623,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               e_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageE();
             }
             input.ReadMessage(e_);
+            E.SetParent(Context, new EventPath(Context.Path, 4));
             break;
           }
           case 40: {
@@ -1973,6 +1976,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           f_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageF();
         }
         F.MergeFrom(other.F);
+      F.SetParent(Context, new EventPath(Context.Path, 5));
       }
       if (other.I != 0) {
         I = other.I;
@@ -2023,6 +2027,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               f_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageF();
             }
             input.ReadMessage(f_);
+            F.SetParent(Context, new EventPath(Context.Path, 5));
             break;
           }
           case 48: {
@@ -2371,6 +2376,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           g_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageG();
         }
         G.MergeFrom(other.G);
+      G.SetParent(Context, new EventPath(Context.Path, 6));
       }
       if (other.I != 0) {
         I = other.I;
@@ -2425,6 +2431,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               g_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageG();
             }
             input.ReadMessage(g_);
+            G.SetParent(Context, new EventPath(Context.Path, 6));
             break;
           }
           case 56: {
@@ -3072,6 +3079,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           p_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageP();
         }
         P.MergeFrom(other.P);
+      P.SetParent(Context, new EventPath(Context.Path, 8));
       }
       if (other.T != 0) {
         T = other.T;
@@ -3097,6 +3105,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               p_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageP();
             }
             input.ReadMessage(p_);
+            P.SetParent(Context, new EventPath(Context.Path, 8));
             break;
           }
           case 72: {
@@ -3359,6 +3368,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           q_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageQ();
         }
         Q.MergeFrom(other.Q);
+      Q.SetParent(Context, new EventPath(Context.Path, 9));
       }
       if (other.S != 0) {
         S = other.S;
@@ -3388,6 +3398,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               q_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageQ();
             }
             input.ReadMessage(q_);
+            Q.SetParent(Context, new EventPath(Context.Path, 9));
             break;
           }
           case 80: {

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
@@ -54,44 +54,41 @@ namespace Com.Zynga.Runtime.Protobuf {
             "BVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAEaXwoQU3RyaW5nVG9G",
             "b29FbnRyeRIQCgNrZXkYASABKAlSA2tleRI1CgV2YWx1ZRgCIAEoCzIfLmNv",
             "bS56eW5nYS5ydW50aW1lLnByb3RvYnVmLkZvb1IFdmFsdWU6AjgBOgTIuB4B",
-            "QgYKBHRlc3QiswIKA0ZvbxISCgRsb25nGAEgASgDUgRsb25nEhAKA3N0chgC",
+            "QgYKBHRlc3QigAIKA0ZvbxISCgRsb25nGAEgASgDUgRsb25nEhAKA3N0chgC",
             "IAEoCVIDc3RyEjEKA2ZvbxgDIAEoCzIfLmNvbS56eW5nYS5ydW50aW1lLnBy",
             "b3RvYnVmLkZvb1IDZm9vEj0KB2VudW1lcm8YBCABKA4yIy5jb20uenluZ2Eu",
             "cnVudGltZS5wcm90b2J1Zi5FbnVtZXJvUgdlbnVtZXJvEjYKBG9rYXkYBSAB",
-            "KA4yIi5jb20uenluZ2EucnVudGltZS5wcm90b2J1Zi5Gb28ub2tSBG9rYXkS",
-            "MQoDYmF6GAwgASgLMh8uY29tLnp5bmdhLnJ1bnRpbWUucHJvdG9idWYuQmF6",
-            "UgNiYXoaFQoDWmFtEg4KAmhpGAEgASgFUgJoaSIMCgJvaxIGCgJISRAAOgTI",
-            "uB4BIj4KA0JhchIxCgNmb28YASABKAsyHy5jb20uenluZ2EucnVudGltZS5w",
-            "cm90b2J1Zi5Gb29SA2ZvbzoEyLgeASIfCgNCYXoSEgoEaW50cxgNIAMoBVIE",
-            "aW50czoEyLgeASLnAQoNQWxsUHJpbWl0aXZlcxIMCgFhGAEgASgNUgFhEgwK",
-            "AWIYAiABKAVSAWISDAoBYxgDIAEoBlIBYxIMCgFkGAQgASgHUgFkEgwKAWUY",
-            "BSABKBBSAWUSDAoBZhgGIAEoD1IBZhIMCgFnGAcgASgBUgFnEgwKAWgYCCAB",
-            "KAJSAWgSDAoBaRgJIAEoCFIBaRIMCgFqGAogASgJUgFqEgwKAWsYCyABKAxS",
-            "AWsSDAoBbBgMIAEoA1IBbBIMCgFtGA0gASgEUgFtEgwKAW4YDiABKBFSAW4S",
-            "DAoBbxgPIAEoElIBbzoEyLgeASL4AgoMUmVjdXJzaXZlTWFwEkMKA21hcBgB",
-            "IAMoCzIxLmNvbS56eW5nYS5ydW50aW1lLnByb3RvYnVmLlJlY3Vyc2l2ZU1h",
-            "cC5NYXBFbnRyeVIDbWFwEkkKCnByaW1pdGl2ZXMYAiABKAsyKS5jb20uenlu",
-            "Z2EucnVudGltZS5wcm90b2J1Zi5BbGxQcmltaXRpdmVzUgpwcmltaXRpdmVz",
-            "Ej0KB2VudW1lcm8YAyABKA4yIy5jb20uenluZ2EucnVudGltZS5wcm90b2J1",
-            "Zi5FbnVtZXJvUgdlbnVtZXJvEjEKA2JhchgEIAEoCzIfLmNvbS56eW5nYS5y",
-            "dW50aW1lLnByb3RvYnVmLkJhclIDYmFyGmAKCE1hcEVudHJ5EhAKA2tleRgB",
-            "IAEoBVIDa2V5Ej4KBXZhbHVlGAIgASgLMiguY29tLnp5bmdhLnJ1bnRpbWUu",
-            "cHJvdG9idWYuUmVjdXJzaXZlTWFwUgV2YWx1ZToCOAE6BMi4HgEikQIKDVJl",
-            "Y3Vyc2l2ZUxpc3QSPQoEbGlzdBgBIAMoCzIpLmNvbS56eW5nYS5ydW50aW1l",
-            "LnByb3RvYnVmLlJlY3Vyc2l2ZUxpc3RSBGxpc3QSSQoKcHJpbWl0aXZlcxgC",
-            "IAEoCzIpLmNvbS56eW5nYS5ydW50aW1lLnByb3RvYnVmLkFsbFByaW1pdGl2",
-            "ZXNSCnByaW1pdGl2ZXMSPQoHZW51bWVybxgDIAEoDjIjLmNvbS56eW5nYS5y",
-            "dW50aW1lLnByb3RvYnVmLkVudW1lcm9SB2VudW1lcm8SMQoDYmFyGAQgASgL",
-            "Mh8uY29tLnp5bmdhLnJ1bnRpbWUucHJvdG9idWYuQmFyUgNiYXI6BMi4HgEq",
-            "LQoHRW51bWVybxIJCgVFTVBUWRAAEg0KCVNPTUVUSElORxABEggKBEhBTFAQ",
-            "AmIGcHJvdG8z"));
+            "KA4yIi5jb20uenluZ2EucnVudGltZS5wcm90b2J1Zi5Gb28ub2tSBG9rYXka",
+            "FQoDWmFtEg4KAmhpGAEgASgFUgJoaSIMCgJvaxIGCgJISRAAOgTIuB4BIj4K",
+            "A0JhchIxCgNmb28YASABKAsyHy5jb20uenluZ2EucnVudGltZS5wcm90b2J1",
+            "Zi5Gb29SA2ZvbzoEyLgeASLnAQoNQWxsUHJpbWl0aXZlcxIMCgFhGAEgASgN",
+            "UgFhEgwKAWIYAiABKAVSAWISDAoBYxgDIAEoBlIBYxIMCgFkGAQgASgHUgFk",
+            "EgwKAWUYBSABKBBSAWUSDAoBZhgGIAEoD1IBZhIMCgFnGAcgASgBUgFnEgwK",
+            "AWgYCCABKAJSAWgSDAoBaRgJIAEoCFIBaRIMCgFqGAogASgJUgFqEgwKAWsY",
+            "CyABKAxSAWsSDAoBbBgMIAEoA1IBbBIMCgFtGA0gASgEUgFtEgwKAW4YDiAB",
+            "KBFSAW4SDAoBbxgPIAEoElIBbzoEyLgeASL4AgoMUmVjdXJzaXZlTWFwEkMK",
+            "A21hcBgBIAMoCzIxLmNvbS56eW5nYS5ydW50aW1lLnByb3RvYnVmLlJlY3Vy",
+            "c2l2ZU1hcC5NYXBFbnRyeVIDbWFwEkkKCnByaW1pdGl2ZXMYAiABKAsyKS5j",
+            "b20uenluZ2EucnVudGltZS5wcm90b2J1Zi5BbGxQcmltaXRpdmVzUgpwcmlt",
+            "aXRpdmVzEj0KB2VudW1lcm8YAyABKA4yIy5jb20uenluZ2EucnVudGltZS5w",
+            "cm90b2J1Zi5FbnVtZXJvUgdlbnVtZXJvEjEKA2JhchgEIAEoCzIfLmNvbS56",
+            "eW5nYS5ydW50aW1lLnByb3RvYnVmLkJhclIDYmFyGmAKCE1hcEVudHJ5EhAK",
+            "A2tleRgBIAEoBVIDa2V5Ej4KBXZhbHVlGAIgASgLMiguY29tLnp5bmdhLnJ1",
+            "bnRpbWUucHJvdG9idWYuUmVjdXJzaXZlTWFwUgV2YWx1ZToCOAE6BMi4HgEi",
+            "kQIKDVJlY3Vyc2l2ZUxpc3QSPQoEbGlzdBgBIAMoCzIpLmNvbS56eW5nYS5y",
+            "dW50aW1lLnByb3RvYnVmLlJlY3Vyc2l2ZUxpc3RSBGxpc3QSSQoKcHJpbWl0",
+            "aXZlcxgCIAEoCzIpLmNvbS56eW5nYS5ydW50aW1lLnByb3RvYnVmLkFsbFBy",
+            "aW1pdGl2ZXNSCnByaW1pdGl2ZXMSPQoHZW51bWVybxgDIAEoDjIjLmNvbS56",
+            "eW5nYS5ydW50aW1lLnByb3RvYnVmLkVudW1lcm9SB2VudW1lcm8SMQoDYmFy",
+            "GAQgASgLMh8uY29tLnp5bmdhLnJ1bnRpbWUucHJvdG9idWYuQmFyUgNiYXI6",
+            "BMi4HgEqLQoHRW51bWVybxIJCgVFTVBUWRAAEg0KCVNPTUVUSElORxABEggK",
+            "BEhBTFAQAmIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Zynga.Protobuf.EventSource.EventPluginReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.TimestampReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.DurationReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Com.Zynga.Runtime.Protobuf.Enumero), }, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.TestBlob), global::Com.Zynga.Runtime.Protobuf.TestBlob.Parser, new[]{ "Bar", "Foo", "IntToString", "StringToFoo", "Ilist", "Slist", "Foolist", "Maybefoo", "Maybeint", "Maybestring", "Zam", "FieldBool", "Timestamp", "Duration", "AllPrims", "TestBlob_" }, new[]{ "Test" }, null, new pbr::GeneratedClrTypeInfo[] { null, null, }),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.Foo), global::Com.Zynga.Runtime.Protobuf.Foo.Parser, new[]{ "Long", "Str", "Foo_", "Enumero", "Okay", "Baz" }, null, new[]{ typeof(global::Com.Zynga.Runtime.Protobuf.Foo.Types.ok) }, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.Foo.Types.Zam), global::Com.Zynga.Runtime.Protobuf.Foo.Types.Zam.Parser, new[]{ "Hi" }, null, null, null)}),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.Foo), global::Com.Zynga.Runtime.Protobuf.Foo.Parser, new[]{ "Long", "Str", "Foo_", "Enumero", "Okay" }, null, new[]{ typeof(global::Com.Zynga.Runtime.Protobuf.Foo.Types.ok) }, new pbr::GeneratedClrTypeInfo[] { new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.Foo.Types.Zam), global::Com.Zynga.Runtime.Protobuf.Foo.Types.Zam.Parser, new[]{ "Hi" }, null, null, null)}),
             new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.Bar), global::Com.Zynga.Runtime.Protobuf.Bar.Parser, new[]{ "Foo" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.Baz), global::Com.Zynga.Runtime.Protobuf.Baz.Parser, new[]{ "Ints" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.AllPrimitives), global::Com.Zynga.Runtime.Protobuf.AllPrimitives.Parser, new[]{ "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.RecursiveMap), global::Com.Zynga.Runtime.Protobuf.RecursiveMap.Parser, new[]{ "Map", "Primitives", "Enumero", "Bar" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Com.Zynga.Runtime.Protobuf.RecursiveList), global::Com.Zynga.Runtime.Protobuf.RecursiveList.Parser, new[]{ "List", "Primitives", "Enumero", "Bar" }, null, null, null)
@@ -1017,7 +1014,6 @@ namespace Com.Zynga.Runtime.Protobuf {
       foo_ = other.foo_ != null ? other.Foo_.Clone() : null;
       enumero_ = other.enumero_;
       okay_ = other.okay_;
-      baz_ = other.baz_ != null ? other.Baz.Clone() : null;
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1112,24 +1108,6 @@ namespace Com.Zynga.Runtime.Protobuf {
       }
     }
 
-    /// <summary>Field number for the "baz" field.</summary>
-    public const int BazFieldNumber = 12;
-    private global::Com.Zynga.Runtime.Protobuf.Baz baz_;
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public global::Com.Zynga.Runtime.Protobuf.Baz Baz {
-      get { return baz_; }
-      set {
-        if(baz_ != null) baz_.ClearParent();
-        value.SetParent(Context, new EventPath(Context.Path, 12));
-        #if !DISABLE_EVENTS
-        if(value == null || !value.Equals(baz_)) {
-          Context.AddSetEvent(12, new zpr.EventSource.EventContent { ByteData = value.ToByteString() });
-        }
-        #endif
-        baz_ = value;
-      }
-    }
-
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as Foo);
@@ -1148,7 +1126,6 @@ namespace Com.Zynga.Runtime.Protobuf {
       if (!object.Equals(Foo_, other.Foo_)) return false;
       if (Enumero != other.Enumero) return false;
       if (Okay != other.Okay) return false;
-      if (!object.Equals(Baz, other.Baz)) return false;
       return true;
     }
 
@@ -1160,7 +1137,6 @@ namespace Com.Zynga.Runtime.Protobuf {
       if (foo_ != null) hash ^= Foo_.GetHashCode();
       if (Enumero != 0) hash ^= Enumero.GetHashCode();
       if (Okay != 0) hash ^= Okay.GetHashCode();
-      if (baz_ != null) hash ^= Baz.GetHashCode();
       return hash;
     }
 
@@ -1191,10 +1167,6 @@ namespace Com.Zynga.Runtime.Protobuf {
         output.WriteRawTag(40);
         output.WriteEnum((int) Okay);
       }
-      if (baz_ != null) {
-        output.WriteRawTag(98);
-        output.WriteMessage(Baz);
-      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1214,9 +1186,6 @@ namespace Com.Zynga.Runtime.Protobuf {
       }
       if (Okay != 0) {
         size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Okay);
-      }
-      if (baz_ != null) {
-        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Baz);
       }
       return size;
     }
@@ -1243,12 +1212,6 @@ namespace Com.Zynga.Runtime.Protobuf {
       }
       if (other.Okay != 0) {
         Okay = other.Okay;
-      }
-      if (other.baz_ != null) {
-        if (baz_ == null) {
-          baz_ = new global::Com.Zynga.Runtime.Protobuf.Baz();
-        }
-        Baz.MergeFrom(other.Baz);
       }
     }
 
@@ -1281,13 +1244,6 @@ namespace Com.Zynga.Runtime.Protobuf {
           }
           case 40: {
             okay_ = (global::Com.Zynga.Runtime.Protobuf.Foo.Types.ok) input.ReadEnum();
-            break;
-          }
-          case 98: {
-            if (baz_ == null) {
-              baz_ = new global::Com.Zynga.Runtime.Protobuf.Baz();
-            }
-            input.ReadMessage(baz_);
             break;
           }
         }
@@ -1496,19 +1452,6 @@ namespace Com.Zynga.Runtime.Protobuf {
             okay_ = (global::Com.Zynga.Runtime.Protobuf.Foo.Types.ok)e.Set.U32;
           }
           break;
-          case 12: {
-            if (e.Path.Count - 1 != pathIndex) {
-              if (baz_ == null) {
-                baz_ = new global::Com.Zynga.Runtime.Protobuf.Baz();
-                baz_.SetParent(Context, new EventPath(Context.Path, 12));
-              }
-              (baz_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
-            } else {
-              baz_  = global::Com.Zynga.Runtime.Protobuf.Baz.Parser.ParseFrom(e.Set.ByteData);
-              baz_.SetParent(Context, new EventPath(Context.Path, 12));
-            }
-          }
-          break;
           default:
             return false;
           break;
@@ -1703,162 +1646,6 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class Baz : zpr::EventRegistry, pb::IMessage<Baz> {
-    private static readonly pb::MessageParser<Baz> _parser = new pb::MessageParser<Baz>(() => new Baz());
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public static pb::MessageParser<Baz> Parser { get { return _parser; } }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public static pbr::MessageDescriptor Descriptor {
-      get { return global::Com.Zynga.Runtime.Protobuf.DeltaTestReflection.Descriptor.MessageTypes[3]; }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
-      get { return Descriptor; }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public Baz() {
-      OnConstruction();
-      ints_.SetContext(Context, 13);
-    }
-
-    partial void OnConstruction();
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public Baz(Baz other) : this() {
-      ints_ = new EventRepeatedField<int>(intsDataConverter, other.Ints.Clone());
-      ints_.SetContext(Context, 13);
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public Baz Clone() {
-      return new Baz(this);
-    }
-
-    public static bool IsEventSourced = true;
-
-    public override void SetParent(EventContext parent, EventPath path) {
-      base.SetParent(parent, path);
-      ints_.SetContext(Context, 13);
-    }
-    /// <summary>Field number for the "ints" field.</summary>
-    public const int IntsFieldNumber = 13;
-    private static readonly pb::FieldCodec<int> _repeated_ints_codec
-        = pb::FieldCodec.ForInt32(106);
-    public class IntsDataConverter: EventDataConverter<int> {
-      public override zpr.EventSource.EventContent GetEventData(int data) {
-        return new zpr.EventSource.EventContent() { I32 = data };
-      }
-      public override int GetItem(zpr.EventSource.EventContent data) {
-        return data.I32;
-      }
-    }
-    private static IntsDataConverter intsDataConverter = new IntsDataConverter();
-    private readonly EventRepeatedField<int> ints_ = new EventRepeatedField<int>(intsDataConverter);
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public EventRepeatedField<int> Ints {
-      get { return ints_; }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public override bool Equals(object other) {
-      return Equals(other as Baz);
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public bool Equals(Baz other) {
-      if (ReferenceEquals(other, null)) {
-        return false;
-      }
-      if (ReferenceEquals(other, this)) {
-        return true;
-      }
-      if(!ints_.Equals(other.ints_)) return false;
-      return true;
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public override int GetHashCode() {
-      int hash = 1;
-      hash ^= ints_.GetHashCode();
-      return hash;
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public override string ToString() {
-      return pb::JsonFormatter.ToDiagnosticString(this);
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void WriteTo(pb::CodedOutputStream output) {
-      ints_.WriteTo(output, _repeated_ints_codec);
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public int CalculateSize() {
-      int size = 0;
-      size += ints_.CalculateSize(_repeated_ints_codec);
-      return size;
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void MergeFrom(Baz other) {
-      if (other == null) {
-        return;
-      }
-      ints_.Add(other.ints_);
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    public void MergeFrom(pb::CodedInputStream input) {
-      uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
-          default:
-            input.SkipLastField();
-            break;
-          case 106:
-          case 104: {
-            ints_.AddEntriesFrom(input, _repeated_ints_codec);
-            break;
-          }
-        }
-      }
-    }
-
-    public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
-        if (e.Path.Count == 0) {
-          this.MergeFrom(e.Set.ByteData);
-          return true;
-        }
-        switch (e.Path[pathIndex]) {
-          case 13: {
-            ints_.ApplyEvent(e.ListEvent);
-          }
-          break;
-          default:
-            return false;
-          break;
-        }
-      return true;
-    }
-
-    public override zpr.EventSource.EventSourceRoot GenerateSnapshot() {
-      ClearEvents();
-      var er = new zpr.EventSource.EventSourceRoot();
-      var setEvent = new zpr.EventSource.EventData {
-        Set = new zpr.EventSource.EventContent {
-          ByteData = this.ToByteString()
-        }
-      };
-      er.Events.Add(setEvent);
-      return er;
-    }
-
-  }
-
   public sealed partial class AllPrimitives : zpr::EventRegistry, pb::IMessage<AllPrimitives> {
     private static readonly pb::MessageParser<AllPrimitives> _parser = new pb::MessageParser<AllPrimitives>(() => new AllPrimitives());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1866,7 +1653,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Com.Zynga.Runtime.Protobuf.DeltaTestReflection.Descriptor.MessageTypes[4]; }
+      get { return global::Com.Zynga.Runtime.Protobuf.DeltaTestReflection.Descriptor.MessageTypes[3]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2540,7 +2327,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Com.Zynga.Runtime.Protobuf.DeltaTestReflection.Descriptor.MessageTypes[5]; }
+      get { return global::Com.Zynga.Runtime.Protobuf.DeltaTestReflection.Descriptor.MessageTypes[4]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -2855,7 +2642,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Com.Zynga.Runtime.Protobuf.DeltaTestReflection.Descriptor.MessageTypes[6]; }
+      get { return global::Com.Zynga.Runtime.Protobuf.DeltaTestReflection.Descriptor.MessageTypes[5]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
@@ -681,14 +681,14 @@ namespace Com.Zynga.Runtime.Protobuf {
           bar_ = new global::Com.Zynga.Runtime.Protobuf.Bar();
         }
         Bar.MergeFrom(other.Bar);
-      Bar.SetParent(Context, new EventPath(Context.Path, 1));
+        Bar.SetParent(Context, new EventPath(Context.Path, 1));
       }
       if (other.foo_ != null) {
         if (foo_ == null) {
           foo_ = new global::Com.Zynga.Runtime.Protobuf.Foo();
         }
         Foo.MergeFrom(other.Foo);
-      Foo.SetParent(Context, new EventPath(Context.Path, 2));
+        Foo.SetParent(Context, new EventPath(Context.Path, 2));
       }
       intToString_.Add(other.intToString_);
       stringToFoo_.Add(other.stringToFoo_);
@@ -721,14 +721,14 @@ namespace Com.Zynga.Runtime.Protobuf {
           allPrims_ = new global::Com.Zynga.Runtime.Protobuf.AllPrimitives();
         }
         AllPrims.MergeFrom(other.AllPrims);
-      AllPrims.SetParent(Context, new EventPath(Context.Path, 15));
+        AllPrims.SetParent(Context, new EventPath(Context.Path, 15));
       }
       if (other.testBlob_ != null) {
         if (testBlob_ == null) {
           testBlob_ = new global::Com.Zynga.Runtime.Protobuf.TestBlob();
         }
         TestBlob_.MergeFrom(other.TestBlob_);
-      TestBlob_.SetParent(Context, new EventPath(Context.Path, 16));
+        TestBlob_.SetParent(Context, new EventPath(Context.Path, 16));
       }
       switch (other.TestCase) {
         case TestOneofCase.Maybefoo:
@@ -1215,7 +1215,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           foo_ = new global::Com.Zynga.Runtime.Protobuf.Foo();
         }
         Foo_.MergeFrom(other.Foo_);
-      Foo_.SetParent(Context, new EventPath(Context.Path, 3));
+        Foo_.SetParent(Context, new EventPath(Context.Path, 3));
       }
       if (other.Enumero != 0) {
         Enumero = other.Enumero;
@@ -1595,7 +1595,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           foo_ = new global::Com.Zynga.Runtime.Protobuf.Foo();
         }
         Foo.MergeFrom(other.Foo);
-      Foo.SetParent(Context, new EventPath(Context.Path, 1));
+        Foo.SetParent(Context, new EventPath(Context.Path, 1));
       }
     }
 
@@ -2541,7 +2541,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           primitives_ = new global::Com.Zynga.Runtime.Protobuf.AllPrimitives();
         }
         Primitives.MergeFrom(other.Primitives);
-      Primitives.SetParent(Context, new EventPath(Context.Path, 2));
+        Primitives.SetParent(Context, new EventPath(Context.Path, 2));
       }
       if (other.Enumero != 0) {
         Enumero = other.Enumero;
@@ -2551,7 +2551,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           bar_ = new global::Com.Zynga.Runtime.Protobuf.Bar();
         }
         Bar.MergeFrom(other.Bar);
-      Bar.SetParent(Context, new EventPath(Context.Path, 4));
+        Bar.SetParent(Context, new EventPath(Context.Path, 4));
       }
     }
 
@@ -2846,7 +2846,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           primitives_ = new global::Com.Zynga.Runtime.Protobuf.AllPrimitives();
         }
         Primitives.MergeFrom(other.Primitives);
-      Primitives.SetParent(Context, new EventPath(Context.Path, 2));
+        Primitives.SetParent(Context, new EventPath(Context.Path, 2));
       }
       if (other.Enumero != 0) {
         Enumero = other.Enumero;
@@ -2856,7 +2856,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           bar_ = new global::Com.Zynga.Runtime.Protobuf.Bar();
         }
         Bar.MergeFrom(other.Bar);
-      Bar.SetParent(Context, new EventPath(Context.Path, 4));
+        Bar.SetParent(Context, new EventPath(Context.Path, 4));
       }
     }
 

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
@@ -681,12 +681,14 @@ namespace Com.Zynga.Runtime.Protobuf {
           bar_ = new global::Com.Zynga.Runtime.Protobuf.Bar();
         }
         Bar.MergeFrom(other.Bar);
+      Bar.SetParent(Context, new EventPath(Context.Path, 1));
       }
       if (other.foo_ != null) {
         if (foo_ == null) {
           foo_ = new global::Com.Zynga.Runtime.Protobuf.Foo();
         }
         Foo.MergeFrom(other.Foo);
+      Foo.SetParent(Context, new EventPath(Context.Path, 2));
       }
       intToString_.Add(other.intToString_);
       stringToFoo_.Add(other.stringToFoo_);
@@ -719,12 +721,14 @@ namespace Com.Zynga.Runtime.Protobuf {
           allPrims_ = new global::Com.Zynga.Runtime.Protobuf.AllPrimitives();
         }
         AllPrims.MergeFrom(other.AllPrims);
+      AllPrims.SetParent(Context, new EventPath(Context.Path, 15));
       }
       if (other.testBlob_ != null) {
         if (testBlob_ == null) {
           testBlob_ = new global::Com.Zynga.Runtime.Protobuf.TestBlob();
         }
         TestBlob_.MergeFrom(other.TestBlob_);
+      TestBlob_.SetParent(Context, new EventPath(Context.Path, 16));
       }
       switch (other.TestCase) {
         case TestOneofCase.Maybefoo:
@@ -732,6 +736,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             Maybefoo = new global::Com.Zynga.Runtime.Protobuf.Foo();
           }
           Maybefoo.MergeFrom(other.Maybefoo);
+          Maybefoo.SetParent(Context, new EventPath(Context.Path, 8));
           break;
         case TestOneofCase.Maybeint:
           Maybeint = other.Maybeint;
@@ -756,6 +761,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               bar_ = new global::Com.Zynga.Runtime.Protobuf.Bar();
             }
             input.ReadMessage(bar_);
+            Bar.SetParent(Context, new EventPath(Context.Path, 1));
             break;
           }
           case 18: {
@@ -763,6 +769,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               foo_ = new global::Com.Zynga.Runtime.Protobuf.Foo();
             }
             input.ReadMessage(foo_);
+            Foo.SetParent(Context, new EventPath(Context.Path, 2));
             break;
           }
           case 26: {
@@ -833,6 +840,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               allPrims_ = new global::Com.Zynga.Runtime.Protobuf.AllPrimitives();
             }
             input.ReadMessage(allPrims_);
+            AllPrims.SetParent(Context, new EventPath(Context.Path, 15));
             break;
           }
           case 130: {
@@ -840,6 +848,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               testBlob_ = new global::Com.Zynga.Runtime.Protobuf.TestBlob();
             }
             input.ReadMessage(testBlob_);
+            TestBlob_.SetParent(Context, new EventPath(Context.Path, 16));
             break;
           }
         }
@@ -1206,6 +1215,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           foo_ = new global::Com.Zynga.Runtime.Protobuf.Foo();
         }
         Foo_.MergeFrom(other.Foo_);
+      Foo_.SetParent(Context, new EventPath(Context.Path, 3));
       }
       if (other.Enumero != 0) {
         Enumero = other.Enumero;
@@ -1236,6 +1246,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               foo_ = new global::Com.Zynga.Runtime.Protobuf.Foo();
             }
             input.ReadMessage(foo_);
+            Foo_.SetParent(Context, new EventPath(Context.Path, 3));
             break;
           }
           case 32: {
@@ -1584,6 +1595,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           foo_ = new global::Com.Zynga.Runtime.Protobuf.Foo();
         }
         Foo.MergeFrom(other.Foo);
+      Foo.SetParent(Context, new EventPath(Context.Path, 1));
       }
     }
 
@@ -1600,6 +1612,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               foo_ = new global::Com.Zynga.Runtime.Protobuf.Foo();
             }
             input.ReadMessage(foo_);
+            Foo.SetParent(Context, new EventPath(Context.Path, 1));
             break;
           }
         }
@@ -2528,6 +2541,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           primitives_ = new global::Com.Zynga.Runtime.Protobuf.AllPrimitives();
         }
         Primitives.MergeFrom(other.Primitives);
+      Primitives.SetParent(Context, new EventPath(Context.Path, 2));
       }
       if (other.Enumero != 0) {
         Enumero = other.Enumero;
@@ -2537,6 +2551,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           bar_ = new global::Com.Zynga.Runtime.Protobuf.Bar();
         }
         Bar.MergeFrom(other.Bar);
+      Bar.SetParent(Context, new EventPath(Context.Path, 4));
       }
     }
 
@@ -2557,6 +2572,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               primitives_ = new global::Com.Zynga.Runtime.Protobuf.AllPrimitives();
             }
             input.ReadMessage(primitives_);
+            Primitives.SetParent(Context, new EventPath(Context.Path, 2));
             break;
           }
           case 24: {
@@ -2568,6 +2584,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               bar_ = new global::Com.Zynga.Runtime.Protobuf.Bar();
             }
             input.ReadMessage(bar_);
+            Bar.SetParent(Context, new EventPath(Context.Path, 4));
             break;
           }
         }
@@ -2829,6 +2846,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           primitives_ = new global::Com.Zynga.Runtime.Protobuf.AllPrimitives();
         }
         Primitives.MergeFrom(other.Primitives);
+      Primitives.SetParent(Context, new EventPath(Context.Path, 2));
       }
       if (other.Enumero != 0) {
         Enumero = other.Enumero;
@@ -2838,6 +2856,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           bar_ = new global::Com.Zynga.Runtime.Protobuf.Bar();
         }
         Bar.MergeFrom(other.Bar);
+      Bar.SetParent(Context, new EventPath(Context.Path, 4));
       }
     }
 
@@ -2858,6 +2877,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               primitives_ = new global::Com.Zynga.Runtime.Protobuf.AllPrimitives();
             }
             input.ReadMessage(primitives_);
+            Primitives.SetParent(Context, new EventPath(Context.Path, 2));
             break;
           }
           case 24: {
@@ -2869,6 +2889,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               bar_ = new global::Com.Zynga.Runtime.Protobuf.Bar();
             }
             input.ReadMessage(bar_);
+            Bar.SetParent(Context, new EventPath(Context.Path, 4));
             break;
           }
         }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
@@ -925,6 +925,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           data_ = new global::Com.Zynga.Runtime.Protobuf.EventTest.Types.EventOneofTest();
         }
         Data.MergeFrom(other.Data);
+      Data.SetParent(Context, new EventPath(Context.Path, 9));
       }
       testMapTwo_.Add(other.testMapTwo_);
       if (other.testNonMessage_ != null) {
@@ -954,6 +955,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             Internal = new global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage();
           }
           Internal.MergeFrom(other.Internal);
+          Internal.SetParent(Context, new EventPath(Context.Path, 3));
           break;
       }
 
@@ -1011,6 +1013,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               data_ = new global::Com.Zynga.Runtime.Protobuf.EventTest.Types.EventOneofTest();
             }
             input.ReadMessage(data_);
+            Data.SetParent(Context, new EventPath(Context.Path, 9));
             break;
           }
           case 82: {
@@ -1195,6 +1198,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               dataTwo_ = new global::Com.Zynga.Runtime.Protobuf.TestTwoMessage();
             }
             DataTwo.MergeFrom(other.DataTwo);
+          DataTwo.SetParent(Context, new EventPath(Context.Path, 2));
           }
         }
 
@@ -1215,6 +1219,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                   dataTwo_ = new global::Com.Zynga.Runtime.Protobuf.TestTwoMessage();
                 }
                 input.ReadMessage(dataTwo_);
+                DataTwo.SetParent(Context, new EventPath(Context.Path, 2));
                 break;
               }
             }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
@@ -925,7 +925,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           data_ = new global::Com.Zynga.Runtime.Protobuf.EventTest.Types.EventOneofTest();
         }
         Data.MergeFrom(other.Data);
-      Data.SetParent(Context, new EventPath(Context.Path, 9));
+        Data.SetParent(Context, new EventPath(Context.Path, 9));
       }
       testMapTwo_.Add(other.testMapTwo_);
       if (other.testNonMessage_ != null) {
@@ -1198,7 +1198,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               dataTwo_ = new global::Com.Zynga.Runtime.Protobuf.TestTwoMessage();
             }
             DataTwo.MergeFrom(other.DataTwo);
-          DataTwo.SetParent(Context, new EventPath(Context.Path, 2));
+            DataTwo.SetParent(Context, new EventPath(Context.Path, 2));
           }
         }
 

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/FileTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/FileTest.cs
@@ -776,14 +776,14 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           bar_ = new global::Com.Zynga.Runtime.Protobuf.File.Bar();
         }
         Bar.MergeFrom(other.Bar);
-      Bar.SetParent(Context, new EventPath(Context.Path, 1));
+        Bar.SetParent(Context, new EventPath(Context.Path, 1));
       }
       if (other.foo_ != null) {
         if (foo_ == null) {
           foo_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
         }
         Foo.MergeFrom(other.Foo);
-      Foo.SetParent(Context, new EventPath(Context.Path, 2));
+        Foo.SetParent(Context, new EventPath(Context.Path, 2));
       }
       intToString_.Add(other.intToString_);
       stringToFoo_.Add(other.stringToFoo_);
@@ -795,7 +795,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           zam_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo.Types.Zam();
         }
         Zam.MergeFrom(other.Zam);
-      Zam.SetParent(Context, new EventPath(Context.Path, 11));
+        Zam.SetParent(Context, new EventPath(Context.Path, 11));
       }
       if (other.FieldBool != false) {
         FieldBool = other.FieldBool;
@@ -817,14 +817,14 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           allPrims_ = new global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives();
         }
         AllPrims.MergeFrom(other.AllPrims);
-      AllPrims.SetParent(Context, new EventPath(Context.Path, 15));
+        AllPrims.SetParent(Context, new EventPath(Context.Path, 15));
       }
       if (other.testBlob_ != null) {
         if (testBlob_ == null) {
           testBlob_ = new global::Com.Zynga.Runtime.Protobuf.File.TestBlob();
         }
         TestBlob_.MergeFrom(other.TestBlob_);
-      TestBlob_.SetParent(Context, new EventPath(Context.Path, 16));
+        TestBlob_.SetParent(Context, new EventPath(Context.Path, 16));
       }
       if (other.noEventsB_ != null) {
         if (noEventsB_ == null) {
@@ -1388,7 +1388,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           foo_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
         }
         Foo_.MergeFrom(other.Foo_);
-      Foo_.SetParent(Context, new EventPath(Context.Path, 3));
+        Foo_.SetParent(Context, new EventPath(Context.Path, 3));
       }
       if (other.Enumero != 0) {
         Enumero = other.Enumero;
@@ -1768,7 +1768,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           foo_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
         }
         Foo.MergeFrom(other.Foo);
-      Foo.SetParent(Context, new EventPath(Context.Path, 1));
+        Foo.SetParent(Context, new EventPath(Context.Path, 1));
       }
     }
 
@@ -2714,7 +2714,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           primitives_ = new global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives();
         }
         Primitives.MergeFrom(other.Primitives);
-      Primitives.SetParent(Context, new EventPath(Context.Path, 2));
+        Primitives.SetParent(Context, new EventPath(Context.Path, 2));
       }
       if (other.Enumero != 0) {
         Enumero = other.Enumero;
@@ -2724,7 +2724,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           bar_ = new global::Com.Zynga.Runtime.Protobuf.File.Bar();
         }
         Bar.MergeFrom(other.Bar);
-      Bar.SetParent(Context, new EventPath(Context.Path, 4));
+        Bar.SetParent(Context, new EventPath(Context.Path, 4));
       }
     }
 
@@ -3019,7 +3019,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           primitives_ = new global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives();
         }
         Primitives.MergeFrom(other.Primitives);
-      Primitives.SetParent(Context, new EventPath(Context.Path, 2));
+        Primitives.SetParent(Context, new EventPath(Context.Path, 2));
       }
       if (other.Enumero != 0) {
         Enumero = other.Enumero;
@@ -3029,7 +3029,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           bar_ = new global::Com.Zynga.Runtime.Protobuf.File.Bar();
         }
         Bar.MergeFrom(other.Bar);
-      Bar.SetParent(Context, new EventPath(Context.Path, 4));
+        Bar.SetParent(Context, new EventPath(Context.Path, 4));
       }
     }
 

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/FileTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/FileTest.cs
@@ -776,12 +776,14 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           bar_ = new global::Com.Zynga.Runtime.Protobuf.File.Bar();
         }
         Bar.MergeFrom(other.Bar);
+      Bar.SetParent(Context, new EventPath(Context.Path, 1));
       }
       if (other.foo_ != null) {
         if (foo_ == null) {
           foo_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
         }
         Foo.MergeFrom(other.Foo);
+      Foo.SetParent(Context, new EventPath(Context.Path, 2));
       }
       intToString_.Add(other.intToString_);
       stringToFoo_.Add(other.stringToFoo_);
@@ -793,6 +795,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           zam_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo.Types.Zam();
         }
         Zam.MergeFrom(other.Zam);
+      Zam.SetParent(Context, new EventPath(Context.Path, 11));
       }
       if (other.FieldBool != false) {
         FieldBool = other.FieldBool;
@@ -814,12 +817,14 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           allPrims_ = new global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives();
         }
         AllPrims.MergeFrom(other.AllPrims);
+      AllPrims.SetParent(Context, new EventPath(Context.Path, 15));
       }
       if (other.testBlob_ != null) {
         if (testBlob_ == null) {
           testBlob_ = new global::Com.Zynga.Runtime.Protobuf.File.TestBlob();
         }
         TestBlob_.MergeFrom(other.TestBlob_);
+      TestBlob_.SetParent(Context, new EventPath(Context.Path, 16));
       }
       if (other.noEventsB_ != null) {
         if (noEventsB_ == null) {
@@ -833,6 +838,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             Maybefoo = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
           }
           Maybefoo.MergeFrom(other.Maybefoo);
+          Maybefoo.SetParent(Context, new EventPath(Context.Path, 8));
           break;
         case TestOneofCase.Maybeint:
           Maybeint = other.Maybeint;
@@ -851,6 +857,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             HasEventsA = new global::Com.Zynga.Runtime.Protobuf.HasEvents();
           }
           HasEventsA.MergeFrom(other.HasEventsA);
+          HasEventsA.SetParent(Context, new EventPath(Context.Path, 19));
           break;
       }
 
@@ -869,6 +876,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               bar_ = new global::Com.Zynga.Runtime.Protobuf.File.Bar();
             }
             input.ReadMessage(bar_);
+            Bar.SetParent(Context, new EventPath(Context.Path, 1));
             break;
           }
           case 18: {
@@ -876,6 +884,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               foo_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
             }
             input.ReadMessage(foo_);
+            Foo.SetParent(Context, new EventPath(Context.Path, 2));
             break;
           }
           case 26: {
@@ -921,6 +930,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               zam_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo.Types.Zam();
             }
             input.ReadMessage(zam_);
+            Zam.SetParent(Context, new EventPath(Context.Path, 11));
             break;
           }
           case 96: {
@@ -946,6 +956,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               allPrims_ = new global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives();
             }
             input.ReadMessage(allPrims_);
+            AllPrims.SetParent(Context, new EventPath(Context.Path, 15));
             break;
           }
           case 130: {
@@ -953,6 +964,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               testBlob_ = new global::Com.Zynga.Runtime.Protobuf.File.TestBlob();
             }
             input.ReadMessage(testBlob_);
+            TestBlob_.SetParent(Context, new EventPath(Context.Path, 16));
             break;
           }
           case 138: {
@@ -1376,6 +1388,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           foo_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
         }
         Foo_.MergeFrom(other.Foo_);
+      Foo_.SetParent(Context, new EventPath(Context.Path, 3));
       }
       if (other.Enumero != 0) {
         Enumero = other.Enumero;
@@ -1406,6 +1419,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               foo_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
             }
             input.ReadMessage(foo_);
+            Foo_.SetParent(Context, new EventPath(Context.Path, 3));
             break;
           }
           case 32: {
@@ -1754,6 +1768,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           foo_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
         }
         Foo.MergeFrom(other.Foo);
+      Foo.SetParent(Context, new EventPath(Context.Path, 1));
       }
     }
 
@@ -1770,6 +1785,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               foo_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
             }
             input.ReadMessage(foo_);
+            Foo.SetParent(Context, new EventPath(Context.Path, 1));
             break;
           }
         }
@@ -2698,6 +2714,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           primitives_ = new global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives();
         }
         Primitives.MergeFrom(other.Primitives);
+      Primitives.SetParent(Context, new EventPath(Context.Path, 2));
       }
       if (other.Enumero != 0) {
         Enumero = other.Enumero;
@@ -2707,6 +2724,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           bar_ = new global::Com.Zynga.Runtime.Protobuf.File.Bar();
         }
         Bar.MergeFrom(other.Bar);
+      Bar.SetParent(Context, new EventPath(Context.Path, 4));
       }
     }
 
@@ -2727,6 +2745,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               primitives_ = new global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives();
             }
             input.ReadMessage(primitives_);
+            Primitives.SetParent(Context, new EventPath(Context.Path, 2));
             break;
           }
           case 24: {
@@ -2738,6 +2757,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               bar_ = new global::Com.Zynga.Runtime.Protobuf.File.Bar();
             }
             input.ReadMessage(bar_);
+            Bar.SetParent(Context, new EventPath(Context.Path, 4));
             break;
           }
         }
@@ -2999,6 +3019,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           primitives_ = new global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives();
         }
         Primitives.MergeFrom(other.Primitives);
+      Primitives.SetParent(Context, new EventPath(Context.Path, 2));
       }
       if (other.Enumero != 0) {
         Enumero = other.Enumero;
@@ -3008,6 +3029,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
           bar_ = new global::Com.Zynga.Runtime.Protobuf.File.Bar();
         }
         Bar.MergeFrom(other.Bar);
+      Bar.SetParent(Context, new EventPath(Context.Path, 4));
       }
     }
 
@@ -3028,6 +3050,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               primitives_ = new global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives();
             }
             input.ReadMessage(primitives_);
+            Primitives.SetParent(Context, new EventPath(Context.Path, 2));
             break;
           }
           case 24: {
@@ -3039,6 +3062,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               bar_ = new global::Com.Zynga.Runtime.Protobuf.File.Bar();
             }
             input.ReadMessage(bar_);
+            Bar.SetParent(Context, new EventPath(Context.Path, 4));
             break;
           }
         }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/ComplexTests.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/ComplexTests.cs
@@ -57,6 +57,11 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 			AssertEventsStable(state);
 
 			AssertEventsStable(state, () => { s.R = "World"; });
+
+			var newState = new MessageO();
+			newState.ApplyEvents(state.GenerateSnapshot());
+
+			AssertEventsStable(newState, () => { newState.P.Q.R[0].R = "Worlds"; });
 		}
 	}
 }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/ComplexTests.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/ComplexTests.cs
@@ -40,5 +40,24 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 			a.B.C["bar"].D["foo"].E.F.G.H.Add(7);
 			AssertEventsStable(a);
 		}
+
+		[Fact]
+		public void DeeplyNestedMessagesInRepeatedFieldShouldApplyEventsProperly() {
+			var state = new MessageO {
+				P = new MessageP {
+					Q = new MessageQ()
+				}
+			};
+
+			var s = new MessageR();
+			s.R = "hello";
+
+			state.P.Q.R.Add(s);
+
+			AssertEventsStable(state);
+
+			s.R = "World";
+			AssertEventsStable(state);
+		}
 	}
 }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/ComplexTests.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/ComplexTests.cs
@@ -56,8 +56,7 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 
 			AssertEventsStable(state);
 
-			s.R = "World";
-			AssertEventsStable(state);
+			AssertEventsStable(state, () => { s.R = "World"; });
 		}
 	}
 }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/DeltaTests.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/DeltaTests.cs
@@ -552,5 +552,52 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 
 			Assert.Equal(blob, blobB);
 		}
+
+		[Fact]
+		public void ChangesToComplexChildMessageBeStableAfterSnapshots() {
+			var blob = populated();
+			var childBlob = populated();
+			blob.TestBlob_ = childBlob;
+
+			var snapshot = blob.GenerateSnapshot();
+
+			var blobA = new TestBlob();
+			blobA.ApplyEvents(snapshot);
+
+			AssertEventsStable(blobA, () => {
+				blobA.TestBlob_.Bar = new Bar();
+				blobA.TestBlob_.Bar.Foo = new Foo();
+				blobA.TestBlob_.Bar.Foo.Long = 10;
+				blobA.TestBlob_.Bar.Foo.Str = "world";
+				blobA.TestBlob_.Foo = new Foo();
+				blobA.TestBlob_.Foo.Long = 12;
+				blobA.TestBlob_.Foo.Str = "hello";
+
+				blobA.TestBlob_.IntToString.Add(11, "world");
+				blobA.TestBlob_.StringToFoo.Add("helloa", new Foo {Long = 9, Str = "ha"});
+				blobA.TestBlob_.StringToFoo["helloa"].Str = "happy";
+				blobA.TestBlob_.StringToFoo["helloa"].Long = 10;
+
+				blobA.TestBlob_.Foolist.Add(new Foo {Long = 123});
+				blobA.TestBlob_.Foolist[2].Long = 321;
+				blobA.TestBlob_.Foolist.Add(new Foo {Long = 1, Str = "la", Foo_ = new Foo()});
+				blobA.TestBlob_.Foolist[3].Str = "lalala";
+				blobA.TestBlob_.Foolist[3].Long = 2;
+
+				blobA.TestBlob_.Ilist.Add(12);
+				blobA.TestBlob_.Ilist.Add(51);
+
+				blobA.TestBlob_.Maybefoo = new Foo {Long = 42, Str = "maybe_foo_who_knows"};
+
+				blobA.TestBlob_.Timestamp = new Timestamp {
+					Seconds = 1235,
+					Nanos = 987
+				};
+				blobA.TestBlob_.Duration = new Duration {
+					Seconds = 112,
+					Nanos = 2
+				};
+			});
+		}
 	}
 }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/EventTestHelper.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/EventTestHelper.cs
@@ -1,4 +1,5 @@
-﻿using Google.Protobuf;
+﻿using System;
+using Google.Protobuf;
 using Xunit;
 using Zynga.Protobuf.Runtime.EventSource;
 
@@ -30,6 +31,19 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 
 		public static void AssertEventsStable<T>(T message) where T : EventRegistry, IMessage, new() {
 			var newMessage = new T();
+			var events = message.GenerateEvents();
+			newMessage.ApplyEvents(events);
+			Assert.Equal(message, newMessage);
+		}
+
+		public static void AssertEventsStable<T>(T message, Action makeChanges) where T : EventRegistry, IMessage, IDeepCloneable<T>, new() {
+			if (message.HasEvents) {
+				message.ClearEvents();
+			}
+			var newMessage = message.Clone();
+
+			makeChanges();
+
 			var events = message.GenerateEvents();
 			newMessage.ApplyEvents(events);
 			Assert.Equal(message, newMessage);

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
@@ -187,7 +187,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           b_ = new global::Com.Zynga.Runtime.Protobuf.ChildMessage();
         }
         B.MergeFrom(other.B);
-      B.SetParent(Context, new EventPath(Context.Path, 2));
+        B.SetParent(Context, new EventPath(Context.Path, 2));
       }
     }
 
@@ -399,7 +399,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           d_ = new global::Com.Zynga.Runtime.Protobuf.ChildChildMessage();
         }
         D.MergeFrom(other.D);
-      D.SetParent(Context, new EventPath(Context.Path, 4));
+        D.SetParent(Context, new EventPath(Context.Path, 4));
       }
     }
 

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
@@ -187,6 +187,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           b_ = new global::Com.Zynga.Runtime.Protobuf.ChildMessage();
         }
         B.MergeFrom(other.B);
+      B.SetParent(Context, new EventPath(Context.Path, 2));
       }
     }
 
@@ -207,6 +208,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               b_ = new global::Com.Zynga.Runtime.Protobuf.ChildMessage();
             }
             input.ReadMessage(b_);
+            B.SetParent(Context, new EventPath(Context.Path, 2));
             break;
           }
         }
@@ -397,6 +399,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           d_ = new global::Com.Zynga.Runtime.Protobuf.ChildChildMessage();
         }
         D.MergeFrom(other.D);
+      D.SetParent(Context, new EventPath(Context.Path, 4));
       }
     }
 
@@ -417,6 +420,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               d_ = new global::Com.Zynga.Runtime.Protobuf.ChildChildMessage();
             }
             input.ReadMessage(d_);
+            D.SetParent(Context, new EventPath(Context.Path, 4));
             break;
           }
         }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/UpgradeTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/UpgradeTest.cs
@@ -768,6 +768,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           nestedA_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage1();
         }
         NestedA.MergeFrom(other.NestedA);
+      NestedA.SetParent(Context, new EventPath(Context.Path, 4));
       }
       listA_.Add(other.listA_);
       mapA_.Add(other.mapA_);
@@ -804,6 +805,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               nestedA_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage1();
             }
             input.ReadMessage(nestedA_);
+            NestedA.SetParent(Context, new EventPath(Context.Path, 4));
             break;
           }
           case 42:
@@ -1207,6 +1209,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           nestedB_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage1();
         }
         NestedB.MergeFrom(other.NestedB);
+      NestedB.SetParent(Context, new EventPath(Context.Path, 4));
       }
       listB_.Add(other.listB_);
       mapB_.Add(other.mapB_);
@@ -1243,6 +1246,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               nestedB_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage1();
             }
             input.ReadMessage(nestedB_);
+            NestedB.SetParent(Context, new EventPath(Context.Path, 4));
             break;
           }
           case 42:
@@ -1701,6 +1705,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           nestedB_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage2();
         }
         NestedB.MergeFrom(other.NestedB);
+      NestedB.SetParent(Context, new EventPath(Context.Path, 4));
       }
       listB_.Add(other.listB_);
       mapB_.Add(other.mapB_);
@@ -1743,6 +1748,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               nestedB_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage2();
             }
             input.ReadMessage(nestedB_);
+            NestedB.SetParent(Context, new EventPath(Context.Path, 4));
             break;
           }
           case 42:
@@ -2160,6 +2166,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           nestedB_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage2();
         }
         NestedB.MergeFrom(other.NestedB);
+      NestedB.SetParent(Context, new EventPath(Context.Path, 4));
       }
       listB_.Add(other.listB_);
       mapB_.Add(other.mapB_);
@@ -2195,6 +2202,7 @@ namespace Com.Zynga.Runtime.Protobuf {
               nestedB_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage2();
             }
             input.ReadMessage(nestedB_);
+            NestedB.SetParent(Context, new EventPath(Context.Path, 4));
             break;
           }
           case 42:

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/UpgradeTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/UpgradeTest.cs
@@ -768,7 +768,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           nestedA_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage1();
         }
         NestedA.MergeFrom(other.NestedA);
-      NestedA.SetParent(Context, new EventPath(Context.Path, 4));
+        NestedA.SetParent(Context, new EventPath(Context.Path, 4));
       }
       listA_.Add(other.listA_);
       mapA_.Add(other.mapA_);
@@ -1209,7 +1209,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           nestedB_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage1();
         }
         NestedB.MergeFrom(other.NestedB);
-      NestedB.SetParent(Context, new EventPath(Context.Path, 4));
+        NestedB.SetParent(Context, new EventPath(Context.Path, 4));
       }
       listB_.Add(other.listB_);
       mapB_.Add(other.mapB_);
@@ -1705,7 +1705,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           nestedB_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage2();
         }
         NestedB.MergeFrom(other.NestedB);
-      NestedB.SetParent(Context, new EventPath(Context.Path, 4));
+        NestedB.SetParent(Context, new EventPath(Context.Path, 4));
       }
       listB_.Add(other.listB_);
       mapB_.Add(other.mapB_);
@@ -2166,7 +2166,7 @@ namespace Com.Zynga.Runtime.Protobuf {
           nestedB_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage2();
         }
         NestedB.MergeFrom(other.NestedB);
-      NestedB.SetParent(Context, new EventPath(Context.Path, 4));
+        NestedB.SetParent(Context, new EventPath(Context.Path, 4));
       }
       listB_.Add(other.listB_);
       mapB_.Add(other.mapB_);


### PR DESCRIPTION
The MergeFrom code was not properly setting the parent when creating a child message.  This left messages orphaned when events were generated.