### PR TITLE
Add support for subscribing to Message, List, and Map events

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,5 +172,5 @@ Build instructions for protoc-gen-zsharp c++ plugin
 
 3.) Build via commandline
 * cd runtime 
-* run ```build.sh|cmd build```
+* run ```build.sh|cmd build``` 
 

--- a/plugin/src/lib/csharp_message.cc
+++ b/plugin/src/lib/csharp_message.cc
@@ -139,7 +139,7 @@ void MessageGenerator::Generate(io::Printer* printer, bool isEventSourced) {
     if (IsEventSourced()) {
       printer->Print(
       vars,
-      " zpr::EventRegistry,");  
+      " zpr::EventRegistry<$class_name$>,");  
     }
     ///
 
@@ -224,6 +224,12 @@ void MessageGenerator::Generate(io::Printer* printer, bool isEventSourced) {
     "public static bool IsEventSourced = $sourced$;\n\n",
     "sourced", IsEventSourced() ? "true" : "false");
 
+  if (IsEventSourced()) {
+    // protected abstract T Message { get; }
+    printer->Print(
+      vars,
+      "protected override $class_name$ Message { get{ return this; } }\n\n");
+  }
   
   if (IsEventSourced()) {
     printer->Print(
@@ -351,6 +357,7 @@ void MessageGenerator::Generate(io::Printer* printer, bool isEventSourced) {
     printer->Print(
       vars,
       "public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {\n"
+      "    MarkDirty();\n"
       "    if (e.Path.Count == 0) {\n"
       "      this.MergeFrom(e.Set.ByteData);\n"
       "      return true;\n"

--- a/plugin/src/lib/csharp_message_field.cc
+++ b/plugin/src/lib/csharp_message_field.cc
@@ -115,7 +115,7 @@ void MessageFieldGenerator::GenerateEventSource(io::Printer* printer) {
       "            $name$_ = new $type_name$();\n"
       "            $name$_.SetParent(Context, new EventPath(Context.Path, $number$));\n"
       "          }\n"
-      "          ($name$_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);\n"
+      "          ($name$_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);\n"
       "        } else {\n"
       "          $name$_  = $type_name$.Parser.ParseFrom(e.Set.ByteData);\n"
       "          $name$_.SetParent(Context, new EventPath(Context.Path, $number$));\n"
@@ -343,12 +343,12 @@ void MessageOneofFieldGenerator::GenerateEventSource(io::Printer* printer) {
       "        if (e.Path.Count - 1 != pathIndex) {\n"
       "          if ($oneof_name$_ == null) {\n"
       "            $oneof_name$_ = new $type_name$();\n"
-      "            ($oneof_name$_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, $number$));\n"
+      "            ($oneof_name$_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, $number$));\n"
       "          }\n"
-      "          ($oneof_name$_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);\n"
+      "          ($oneof_name$_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);\n"
       "        } else {\n"
       "          $oneof_name$_   = $type_name$.Parser.ParseFrom(e.Set.ByteData);\n"
-      "          ($oneof_name$_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, $number$));\n"
+      "          ($oneof_name$_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, $number$));\n"
       "        }\n");
   }
   else {

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/ComplexTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/ComplexTest.cs
@@ -87,7 +87,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
   #region Messages
-  public sealed partial class MessageA : zpr::EventRegistry, pb::IMessage<MessageA> {
+  public sealed partial class MessageA : zpr::EventRegistry<MessageA>, pb::IMessage<MessageA> {
     private static readonly pb::MessageParser<MessageA> _parser = new pb::MessageParser<MessageA>(() => new MessageA());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<MessageA> Parser { get { return _parser; } }
@@ -131,6 +131,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override MessageA Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -452,6 +454,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -461,12 +464,12 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             if (e.Path.Count - 1 != pathIndex) {
               if (a_ == null) {
                 a_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageB();
-                (a_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 1));
+                (a_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 1));
               }
-              (a_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (a_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               a_   = global::Com.Zynga.Runtime.Protobuf.File.MessageB.Parser.ParseFrom(e.Set.ByteData);
-              (a_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 1));
+              (a_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 1));
             }
             aCase_ = a_ == null ? AOneofCase.None : AOneofCase.B;
           }
@@ -516,7 +519,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class MessageB : zpr::EventRegistry, pb::IMessage<MessageB> {
+  public sealed partial class MessageB : zpr::EventRegistry<MessageB>, pb::IMessage<MessageB> {
     private static readonly pb::MessageParser<MessageB> _parser = new pb::MessageParser<MessageB>(() => new MessageB());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<MessageB> Parser { get { return _parser; } }
@@ -557,6 +560,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override MessageB Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -857,6 +862,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -911,7 +917,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class MessageC : zpr::EventRegistry, pb::IMessage<MessageC> {
+  public sealed partial class MessageC : zpr::EventRegistry<MessageC>, pb::IMessage<MessageC> {
     private static readonly pb::MessageParser<MessageC> _parser = new pb::MessageParser<MessageC>(() => new MessageC());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<MessageC> Parser { get { return _parser; } }
@@ -952,6 +958,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override MessageC Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -1252,6 +1260,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -1306,7 +1315,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class MessageD : zpr::EventRegistry, pb::IMessage<MessageD> {
+  public sealed partial class MessageD : zpr::EventRegistry<MessageD>, pb::IMessage<MessageD> {
     private static readonly pb::MessageParser<MessageD> _parser = new pb::MessageParser<MessageD>(() => new MessageD());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<MessageD> Parser { get { return _parser; } }
@@ -1345,6 +1354,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override MessageD Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -1643,6 +1654,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -1654,7 +1666,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 e_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageE();
                 e_.SetParent(Context, new EventPath(Context.Path, 4));
               }
-              (e_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (e_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               e_  = global::Com.Zynga.Runtime.Protobuf.File.MessageE.Parser.ParseFrom(e.Set.ByteData);
               e_.SetParent(Context, new EventPath(Context.Path, 4));
@@ -1706,7 +1718,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class MessageE : zpr::EventRegistry, pb::IMessage<MessageE> {
+  public sealed partial class MessageE : zpr::EventRegistry<MessageE>, pb::IMessage<MessageE> {
     private static readonly pb::MessageParser<MessageE> _parser = new pb::MessageParser<MessageE>(() => new MessageE());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<MessageE> Parser { get { return _parser; } }
@@ -1745,6 +1757,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override MessageE Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -2043,6 +2057,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -2054,7 +2069,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 f_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageF();
                 f_.SetParent(Context, new EventPath(Context.Path, 5));
               }
-              (f_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (f_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               f_  = global::Com.Zynga.Runtime.Protobuf.File.MessageF.Parser.ParseFrom(e.Set.ByteData);
               f_.SetParent(Context, new EventPath(Context.Path, 5));
@@ -2106,7 +2121,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class MessageF : zpr::EventRegistry, pb::IMessage<MessageF> {
+  public sealed partial class MessageF : zpr::EventRegistry<MessageF>, pb::IMessage<MessageF> {
     private static readonly pb::MessageParser<MessageF> _parser = new pb::MessageParser<MessageF>(() => new MessageF());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<MessageF> Parser { get { return _parser; } }
@@ -2145,6 +2160,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override MessageF Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -2443,6 +2460,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -2454,7 +2472,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 g_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageG();
                 g_.SetParent(Context, new EventPath(Context.Path, 6));
               }
-              (g_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (g_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               g_  = global::Com.Zynga.Runtime.Protobuf.File.MessageG.Parser.ParseFrom(e.Set.ByteData);
               g_.SetParent(Context, new EventPath(Context.Path, 6));
@@ -2506,7 +2524,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class MessageG : zpr::EventRegistry, pb::IMessage<MessageG> {
+  public sealed partial class MessageG : zpr::EventRegistry<MessageG>, pb::IMessage<MessageG> {
     private static readonly pb::MessageParser<MessageG> _parser = new pb::MessageParser<MessageG>(() => new MessageG());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<MessageG> Parser { get { return _parser; } }
@@ -2547,6 +2565,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override MessageG Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -2833,6 +2853,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -2887,7 +2908,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class MessageO : zpr::EventRegistry, pb::IMessage<MessageO> {
+  public sealed partial class MessageO : zpr::EventRegistry<MessageO>, pb::IMessage<MessageO> {
     private static readonly pb::MessageParser<MessageO> _parser = new pb::MessageParser<MessageO>(() => new MessageO());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<MessageO> Parser { get { return _parser; } }
@@ -2923,6 +2944,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override MessageO Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -3125,6 +3148,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -3136,7 +3160,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 p_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageP();
                 p_.SetParent(Context, new EventPath(Context.Path, 8));
               }
-              (p_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (p_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               p_  = global::Com.Zynga.Runtime.Protobuf.File.MessageP.Parser.ParseFrom(e.Set.ByteData);
               p_.SetParent(Context, new EventPath(Context.Path, 8));
@@ -3176,7 +3200,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class MessageP : zpr::EventRegistry, pb::IMessage<MessageP> {
+  public sealed partial class MessageP : zpr::EventRegistry<MessageP>, pb::IMessage<MessageP> {
     private static readonly pb::MessageParser<MessageP> _parser = new pb::MessageParser<MessageP>(() => new MessageP());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<MessageP> Parser { get { return _parser; } }
@@ -3212,6 +3236,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override MessageP Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -3414,6 +3440,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -3425,7 +3452,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 q_ = new global::Com.Zynga.Runtime.Protobuf.File.MessageQ();
                 q_.SetParent(Context, new EventPath(Context.Path, 9));
               }
-              (q_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (q_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               q_  = global::Com.Zynga.Runtime.Protobuf.File.MessageQ.Parser.ParseFrom(e.Set.ByteData);
               q_.SetParent(Context, new EventPath(Context.Path, 9));
@@ -3465,7 +3492,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class MessageQ : zpr::EventRegistry, pb::IMessage<MessageQ> {
+  public sealed partial class MessageQ : zpr::EventRegistry<MessageQ>, pb::IMessage<MessageQ> {
     private static readonly pb::MessageParser<MessageQ> _parser = new pb::MessageParser<MessageQ>(() => new MessageQ());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<MessageQ> Parser { get { return _parser; } }
@@ -3503,6 +3530,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override MessageQ Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -3693,6 +3722,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -3735,7 +3765,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class MessageR : zpr::EventRegistry, pb::IMessage<MessageR> {
+  public sealed partial class MessageR : zpr::EventRegistry<MessageR>, pb::IMessage<MessageR> {
     private static readonly pb::MessageParser<MessageR> _parser = new pb::MessageParser<MessageR>(() => new MessageR());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<MessageR> Parser { get { return _parser; } }
@@ -3771,6 +3801,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override MessageR Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -3963,6 +3995,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
@@ -107,7 +107,7 @@ namespace Com.Zynga.Runtime.Protobuf {
   #endregion
 
   #region Messages
-  public sealed partial class TestBlob : zpr::EventRegistry, pb::IMessage<TestBlob> {
+  public sealed partial class TestBlob : zpr::EventRegistry<TestBlob>, pb::IMessage<TestBlob> {
     private static readonly pb::MessageParser<TestBlob> _parser = new pb::MessageParser<TestBlob>(() => new TestBlob());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestBlob> Parser { get { return _parser; } }
@@ -174,6 +174,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestBlob Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -856,6 +858,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -867,7 +870,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 bar_ = new global::Com.Zynga.Runtime.Protobuf.Bar();
                 bar_.SetParent(Context, new EventPath(Context.Path, 1));
               }
-              (bar_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (bar_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               bar_  = global::Com.Zynga.Runtime.Protobuf.Bar.Parser.ParseFrom(e.Set.ByteData);
               bar_.SetParent(Context, new EventPath(Context.Path, 1));
@@ -880,7 +883,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 foo_ = new global::Com.Zynga.Runtime.Protobuf.Foo();
                 foo_.SetParent(Context, new EventPath(Context.Path, 2));
               }
-              (foo_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (foo_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               foo_  = global::Com.Zynga.Runtime.Protobuf.Foo.Parser.ParseFrom(e.Set.ByteData);
               foo_.SetParent(Context, new EventPath(Context.Path, 2));
@@ -911,12 +914,12 @@ namespace Com.Zynga.Runtime.Protobuf {
             if (e.Path.Count - 1 != pathIndex) {
               if (test_ == null) {
                 test_ = new global::Com.Zynga.Runtime.Protobuf.Foo();
-                (test_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 8));
+                (test_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 8));
               }
-              (test_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (test_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               test_   = global::Com.Zynga.Runtime.Protobuf.Foo.Parser.ParseFrom(e.Set.ByteData);
-              (test_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 8));
+              (test_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 8));
             }
             testCase_ = test_ == null ? TestOneofCase.None : TestOneofCase.Maybefoo;
           }
@@ -953,7 +956,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 allPrims_ = new global::Com.Zynga.Runtime.Protobuf.AllPrimitives();
                 allPrims_.SetParent(Context, new EventPath(Context.Path, 15));
               }
-              (allPrims_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (allPrims_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               allPrims_  = global::Com.Zynga.Runtime.Protobuf.AllPrimitives.Parser.ParseFrom(e.Set.ByteData);
               allPrims_.SetParent(Context, new EventPath(Context.Path, 15));
@@ -966,7 +969,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 testBlob_ = new global::Com.Zynga.Runtime.Protobuf.TestBlob();
                 testBlob_.SetParent(Context, new EventPath(Context.Path, 16));
               }
-              (testBlob_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (testBlob_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               testBlob_  = global::Com.Zynga.Runtime.Protobuf.TestBlob.Parser.ParseFrom(e.Set.ByteData);
               testBlob_.SetParent(Context, new EventPath(Context.Path, 16));
@@ -994,7 +997,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class Foo : zpr::EventRegistry, pb::IMessage<Foo> {
+  public sealed partial class Foo : zpr::EventRegistry<Foo>, pb::IMessage<Foo> {
     private static readonly pb::MessageParser<Foo> _parser = new pb::MessageParser<Foo>(() => new Foo());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<Foo> Parser { get { return _parser; } }
@@ -1031,6 +1034,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override Foo Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -1269,7 +1274,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         [pbr::OriginalName("HI")] Hi = 0,
       }
 
-      public sealed partial class Zam : zpr::EventRegistry, pb::IMessage<Zam> {
+      public sealed partial class Zam : zpr::EventRegistry<Zam>, pb::IMessage<Zam> {
         private static readonly pb::MessageParser<Zam> _parser = new pb::MessageParser<Zam>(() => new Zam());
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pb::MessageParser<Zam> Parser { get { return _parser; } }
@@ -1302,6 +1307,8 @@ namespace Com.Zynga.Runtime.Protobuf {
         }
 
         public static bool IsEventSourced = true;
+
+        protected override Zam Message { get{ return this; } }
 
         public override void SetParent(EventContext parent, EventPath path) {
           base.SetParent(parent, path);
@@ -1395,6 +1402,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         }
 
         public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+            MarkDirty();
             if (e.Path.Count == 0) {
               this.MergeFrom(e.Set.ByteData);
               return true;
@@ -1429,6 +1437,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     #endregion
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -1448,7 +1457,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 foo_ = new global::Com.Zynga.Runtime.Protobuf.Foo();
                 foo_.SetParent(Context, new EventPath(Context.Path, 3));
               }
-              (foo_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (foo_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               foo_  = global::Com.Zynga.Runtime.Protobuf.Foo.Parser.ParseFrom(e.Set.ByteData);
               foo_.SetParent(Context, new EventPath(Context.Path, 3));
@@ -1484,7 +1493,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class Bar : zpr::EventRegistry, pb::IMessage<Bar> {
+  public sealed partial class Bar : zpr::EventRegistry<Bar>, pb::IMessage<Bar> {
     private static readonly pb::MessageParser<Bar> _parser = new pb::MessageParser<Bar>(() => new Bar());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<Bar> Parser { get { return _parser; } }
@@ -1517,6 +1526,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override Bar Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -1620,6 +1631,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -1631,7 +1643,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 foo_ = new global::Com.Zynga.Runtime.Protobuf.Foo();
                 foo_.SetParent(Context, new EventPath(Context.Path, 1));
               }
-              (foo_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (foo_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               foo_  = global::Com.Zynga.Runtime.Protobuf.Foo.Parser.ParseFrom(e.Set.ByteData);
               foo_.SetParent(Context, new EventPath(Context.Path, 1));
@@ -1659,7 +1671,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class AllPrimitives : zpr::EventRegistry, pb::IMessage<AllPrimitives> {
+  public sealed partial class AllPrimitives : zpr::EventRegistry<AllPrimitives>, pb::IMessage<AllPrimitives> {
     private static readonly pb::MessageParser<AllPrimitives> _parser = new pb::MessageParser<AllPrimitives>(() => new AllPrimitives());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<AllPrimitives> Parser { get { return _parser; } }
@@ -1706,6 +1718,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override AllPrimitives Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -2247,6 +2261,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -2333,7 +2348,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class RecursiveMap : zpr::EventRegistry, pb::IMessage<RecursiveMap> {
+  public sealed partial class RecursiveMap : zpr::EventRegistry<RecursiveMap>, pb::IMessage<RecursiveMap> {
     private static readonly pb::MessageParser<RecursiveMap> _parser = new pb::MessageParser<RecursiveMap>(() => new RecursiveMap());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<RecursiveMap> Parser { get { return _parser; } }
@@ -2371,6 +2386,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override RecursiveMap Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -2592,6 +2609,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -2607,7 +2625,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 primitives_ = new global::Com.Zynga.Runtime.Protobuf.AllPrimitives();
                 primitives_.SetParent(Context, new EventPath(Context.Path, 2));
               }
-              (primitives_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (primitives_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               primitives_  = global::Com.Zynga.Runtime.Protobuf.AllPrimitives.Parser.ParseFrom(e.Set.ByteData);
               primitives_.SetParent(Context, new EventPath(Context.Path, 2));
@@ -2624,7 +2642,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 bar_ = new global::Com.Zynga.Runtime.Protobuf.Bar();
                 bar_.SetParent(Context, new EventPath(Context.Path, 4));
               }
-              (bar_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (bar_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               bar_  = global::Com.Zynga.Runtime.Protobuf.Bar.Parser.ParseFrom(e.Set.ByteData);
               bar_.SetParent(Context, new EventPath(Context.Path, 4));
@@ -2652,7 +2670,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class RecursiveList : zpr::EventRegistry, pb::IMessage<RecursiveList> {
+  public sealed partial class RecursiveList : zpr::EventRegistry<RecursiveList>, pb::IMessage<RecursiveList> {
     private static readonly pb::MessageParser<RecursiveList> _parser = new pb::MessageParser<RecursiveList>(() => new RecursiveList());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<RecursiveList> Parser { get { return _parser; } }
@@ -2690,6 +2708,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override RecursiveList Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -2897,6 +2917,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -2912,7 +2933,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 primitives_ = new global::Com.Zynga.Runtime.Protobuf.AllPrimitives();
                 primitives_.SetParent(Context, new EventPath(Context.Path, 2));
               }
-              (primitives_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (primitives_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               primitives_  = global::Com.Zynga.Runtime.Protobuf.AllPrimitives.Parser.ParseFrom(e.Set.ByteData);
               primitives_.SetParent(Context, new EventPath(Context.Path, 2));
@@ -2929,7 +2950,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 bar_ = new global::Com.Zynga.Runtime.Protobuf.Bar();
                 bar_.SetParent(Context, new EventPath(Context.Path, 4));
               }
-              (bar_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (bar_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               bar_  = global::Com.Zynga.Runtime.Protobuf.Bar.Parser.ParseFrom(e.Set.ByteData);
               bar_.SetParent(Context, new EventPath(Context.Path, 4));

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
@@ -211,7 +211,7 @@ namespace Com.Zynga.Runtime.Protobuf {
   /// <summary>
   /// must flag internal message as event_sourced
   /// </summary>
-  public sealed partial class TestTwoMessage : zpr::EventRegistry, pb::IMessage<TestTwoMessage> {
+  public sealed partial class TestTwoMessage : zpr::EventRegistry<TestTwoMessage>, pb::IMessage<TestTwoMessage> {
     private static readonly pb::MessageParser<TestTwoMessage> _parser = new pb::MessageParser<TestTwoMessage>(() => new TestTwoMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestTwoMessage> Parser { get { return _parser; } }
@@ -244,6 +244,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestTwoMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -341,6 +343,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -371,7 +374,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class EventTest : zpr::EventRegistry, pb::IMessage<EventTest> {
+  public sealed partial class EventTest : zpr::EventRegistry<EventTest>, pb::IMessage<EventTest> {
     private static readonly pb::MessageParser<EventTest> _parser = new pb::MessageParser<EventTest>(() => new EventTest());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<EventTest> Parser { get { return _parser; } }
@@ -434,6 +437,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override EventTest Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -1053,7 +1058,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       /// <summary>
       /// must flag internal message as event_sourced
       /// </summary>
-      public sealed partial class NestedMessage : zpr::EventRegistry, pb::IMessage<NestedMessage> {
+      public sealed partial class NestedMessage : zpr::EventRegistry<NestedMessage>, pb::IMessage<NestedMessage> {
         private static readonly pb::MessageParser<NestedMessage> _parser = new pb::MessageParser<NestedMessage>(() => new NestedMessage());
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pb::MessageParser<NestedMessage> Parser { get { return _parser; } }
@@ -1087,6 +1092,8 @@ namespace Com.Zynga.Runtime.Protobuf {
         }
 
         public static bool IsEventSourced = true;
+
+        protected override NestedMessage Message { get{ return this; } }
 
         public override void SetParent(EventContext parent, EventPath path) {
           base.SetParent(parent, path);
@@ -1227,6 +1234,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         }
 
         public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+            MarkDirty();
             if (e.Path.Count == 0) {
               this.MergeFrom(e.Set.ByteData);
               return true;
@@ -1242,7 +1250,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                     dataTwo_ = new global::Com.Zynga.Runtime.Protobuf.TestTwoMessage();
                     dataTwo_.SetParent(Context, new EventPath(Context.Path, 2));
                   }
-                  (dataTwo_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+                  (dataTwo_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
                 } else {
                   dataTwo_  = global::Com.Zynga.Runtime.Protobuf.TestTwoMessage.Parser.ParseFrom(e.Set.ByteData);
                   dataTwo_.SetParent(Context, new EventPath(Context.Path, 2));
@@ -1270,7 +1278,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
       }
 
-      public sealed partial class EventOneofTest : zpr::EventRegistry, pb::IMessage<EventOneofTest> {
+      public sealed partial class EventOneofTest : zpr::EventRegistry<EventOneofTest>, pb::IMessage<EventOneofTest> {
         private static readonly pb::MessageParser<EventOneofTest> _parser = new pb::MessageParser<EventOneofTest>(() => new EventOneofTest());
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pb::MessageParser<EventOneofTest> Parser { get { return _parser; } }
@@ -1311,6 +1319,8 @@ namespace Com.Zynga.Runtime.Protobuf {
         }
 
         public static bool IsEventSourced = true;
+
+        protected override EventOneofTest Message { get{ return this; } }
 
         public override void SetParent(EventContext parent, EventPath path) {
           base.SetParent(parent, path);
@@ -1472,6 +1482,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         }
 
         public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+            MarkDirty();
             if (e.Path.Count == 0) {
               this.MergeFrom(e.Set.ByteData);
               return true;
@@ -1512,6 +1523,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     #endregion
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -1530,12 +1542,12 @@ namespace Com.Zynga.Runtime.Protobuf {
             if (e.Path.Count - 1 != pathIndex) {
               if (testOneof_ == null) {
                 testOneof_ = new global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage();
-                (testOneof_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 3));
+                (testOneof_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 3));
               }
-              (testOneof_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (testOneof_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               testOneof_   = global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage.Parser.ParseFrom(e.Set.ByteData);
-              (testOneof_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 3));
+              (testOneof_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 3));
             }
             testOneofCase_ = testOneof_ == null ? TestOneofOneofCase.None : TestOneofOneofCase.Internal;
           }
@@ -1566,7 +1578,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 data_ = new global::Com.Zynga.Runtime.Protobuf.EventTest.Types.EventOneofTest();
                 data_.SetParent(Context, new EventPath(Context.Path, 9));
               }
-              (data_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (data_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               data_  = global::Com.Zynga.Runtime.Protobuf.EventTest.Types.EventOneofTest.Parser.ParseFrom(e.Set.ByteData);
               data_.SetParent(Context, new EventPath(Context.Path, 9));

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/FileTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/FileTest.cs
@@ -114,7 +114,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
   #endregion
 
   #region Messages
-  public sealed partial class TestBlob : zpr::EventRegistry, pb::IMessage<TestBlob> {
+  public sealed partial class TestBlob : zpr::EventRegistry<TestBlob>, pb::IMessage<TestBlob> {
     private static readonly pb::MessageParser<TestBlob> _parser = new pb::MessageParser<TestBlob>(() => new TestBlob());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestBlob> Parser { get { return _parser; } }
@@ -188,6 +188,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestBlob Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -997,6 +999,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -1008,7 +1011,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 bar_ = new global::Com.Zynga.Runtime.Protobuf.File.Bar();
                 bar_.SetParent(Context, new EventPath(Context.Path, 1));
               }
-              (bar_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (bar_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               bar_  = global::Com.Zynga.Runtime.Protobuf.File.Bar.Parser.ParseFrom(e.Set.ByteData);
               bar_.SetParent(Context, new EventPath(Context.Path, 1));
@@ -1021,7 +1024,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 foo_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
                 foo_.SetParent(Context, new EventPath(Context.Path, 2));
               }
-              (foo_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (foo_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               foo_  = global::Com.Zynga.Runtime.Protobuf.File.Foo.Parser.ParseFrom(e.Set.ByteData);
               foo_.SetParent(Context, new EventPath(Context.Path, 2));
@@ -1052,12 +1055,12 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             if (e.Path.Count - 1 != pathIndex) {
               if (test_ == null) {
                 test_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
-                (test_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 8));
+                (test_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 8));
               }
-              (test_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (test_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               test_   = global::Com.Zynga.Runtime.Protobuf.File.Foo.Parser.ParseFrom(e.Set.ByteData);
-              (test_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 8));
+              (test_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 8));
             }
             testCase_ = test_ == null ? TestOneofCase.None : TestOneofCase.Maybefoo;
           }
@@ -1081,12 +1084,12 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             if (e.Path.Count - 1 != pathIndex) {
               if (test_ == null) {
                 test_ = new global::Com.Zynga.Runtime.Protobuf.HasEvents();
-                (test_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 19));
+                (test_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 19));
               }
-              (test_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (test_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               test_   = global::Com.Zynga.Runtime.Protobuf.HasEvents.Parser.ParseFrom(e.Set.ByteData);
-              (test_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 19));
+              (test_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 19));
             }
             testCase_ = test_ == null ? TestOneofCase.None : TestOneofCase.HasEventsA;
           }
@@ -1097,7 +1100,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 zam_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo.Types.Zam();
                 zam_.SetParent(Context, new EventPath(Context.Path, 11));
               }
-              (zam_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (zam_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               zam_  = global::Com.Zynga.Runtime.Protobuf.File.Foo.Types.Zam.Parser.ParseFrom(e.Set.ByteData);
               zam_.SetParent(Context, new EventPath(Context.Path, 11));
@@ -1122,7 +1125,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 allPrims_ = new global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives();
                 allPrims_.SetParent(Context, new EventPath(Context.Path, 15));
               }
-              (allPrims_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (allPrims_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               allPrims_  = global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives.Parser.ParseFrom(e.Set.ByteData);
               allPrims_.SetParent(Context, new EventPath(Context.Path, 15));
@@ -1135,7 +1138,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 testBlob_ = new global::Com.Zynga.Runtime.Protobuf.File.TestBlob();
                 testBlob_.SetParent(Context, new EventPath(Context.Path, 16));
               }
-              (testBlob_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (testBlob_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               testBlob_  = global::Com.Zynga.Runtime.Protobuf.File.TestBlob.Parser.ParseFrom(e.Set.ByteData);
               testBlob_.SetParent(Context, new EventPath(Context.Path, 16));
@@ -1167,7 +1170,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class Foo : zpr::EventRegistry, pb::IMessage<Foo> {
+  public sealed partial class Foo : zpr::EventRegistry<Foo>, pb::IMessage<Foo> {
     private static readonly pb::MessageParser<Foo> _parser = new pb::MessageParser<Foo>(() => new Foo());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<Foo> Parser { get { return _parser; } }
@@ -1204,6 +1207,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override Foo Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -1442,7 +1447,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         [pbr::OriginalName("HI")] Hi = 0,
       }
 
-      public sealed partial class Zam : zpr::EventRegistry, pb::IMessage<Zam> {
+      public sealed partial class Zam : zpr::EventRegistry<Zam>, pb::IMessage<Zam> {
         private static readonly pb::MessageParser<Zam> _parser = new pb::MessageParser<Zam>(() => new Zam());
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pb::MessageParser<Zam> Parser { get { return _parser; } }
@@ -1475,6 +1480,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         }
 
         public static bool IsEventSourced = true;
+
+        protected override Zam Message { get{ return this; } }
 
         public override void SetParent(EventContext parent, EventPath path) {
           base.SetParent(parent, path);
@@ -1568,6 +1575,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         }
 
         public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+            MarkDirty();
             if (e.Path.Count == 0) {
               this.MergeFrom(e.Set.ByteData);
               return true;
@@ -1602,6 +1610,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     #endregion
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -1621,7 +1630,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 foo_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
                 foo_.SetParent(Context, new EventPath(Context.Path, 3));
               }
-              (foo_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (foo_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               foo_  = global::Com.Zynga.Runtime.Protobuf.File.Foo.Parser.ParseFrom(e.Set.ByteData);
               foo_.SetParent(Context, new EventPath(Context.Path, 3));
@@ -1657,7 +1666,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class Bar : zpr::EventRegistry, pb::IMessage<Bar> {
+  public sealed partial class Bar : zpr::EventRegistry<Bar>, pb::IMessage<Bar> {
     private static readonly pb::MessageParser<Bar> _parser = new pb::MessageParser<Bar>(() => new Bar());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<Bar> Parser { get { return _parser; } }
@@ -1690,6 +1699,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override Bar Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -1793,6 +1804,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -1804,7 +1816,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 foo_ = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
                 foo_.SetParent(Context, new EventPath(Context.Path, 1));
               }
-              (foo_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (foo_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               foo_  = global::Com.Zynga.Runtime.Protobuf.File.Foo.Parser.ParseFrom(e.Set.ByteData);
               foo_.SetParent(Context, new EventPath(Context.Path, 1));
@@ -1832,7 +1844,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class AllPrimitives : zpr::EventRegistry, pb::IMessage<AllPrimitives> {
+  public sealed partial class AllPrimitives : zpr::EventRegistry<AllPrimitives>, pb::IMessage<AllPrimitives> {
     private static readonly pb::MessageParser<AllPrimitives> _parser = new pb::MessageParser<AllPrimitives>(() => new AllPrimitives());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<AllPrimitives> Parser { get { return _parser; } }
@@ -1879,6 +1891,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override AllPrimitives Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -2420,6 +2434,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -2506,7 +2521,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class RecursiveMap : zpr::EventRegistry, pb::IMessage<RecursiveMap> {
+  public sealed partial class RecursiveMap : zpr::EventRegistry<RecursiveMap>, pb::IMessage<RecursiveMap> {
     private static readonly pb::MessageParser<RecursiveMap> _parser = new pb::MessageParser<RecursiveMap>(() => new RecursiveMap());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<RecursiveMap> Parser { get { return _parser; } }
@@ -2544,6 +2559,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override RecursiveMap Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -2765,6 +2782,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -2780,7 +2798,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 primitives_ = new global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives();
                 primitives_.SetParent(Context, new EventPath(Context.Path, 2));
               }
-              (primitives_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (primitives_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               primitives_  = global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives.Parser.ParseFrom(e.Set.ByteData);
               primitives_.SetParent(Context, new EventPath(Context.Path, 2));
@@ -2797,7 +2815,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 bar_ = new global::Com.Zynga.Runtime.Protobuf.File.Bar();
                 bar_.SetParent(Context, new EventPath(Context.Path, 4));
               }
-              (bar_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (bar_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               bar_  = global::Com.Zynga.Runtime.Protobuf.File.Bar.Parser.ParseFrom(e.Set.ByteData);
               bar_.SetParent(Context, new EventPath(Context.Path, 4));
@@ -2825,7 +2843,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
 
   }
 
-  public sealed partial class RecursiveList : zpr::EventRegistry, pb::IMessage<RecursiveList> {
+  public sealed partial class RecursiveList : zpr::EventRegistry<RecursiveList>, pb::IMessage<RecursiveList> {
     private static readonly pb::MessageParser<RecursiveList> _parser = new pb::MessageParser<RecursiveList>(() => new RecursiveList());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<RecursiveList> Parser { get { return _parser; } }
@@ -2863,6 +2881,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override RecursiveList Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -3070,6 +3090,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -3085,7 +3106,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 primitives_ = new global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives();
                 primitives_.SetParent(Context, new EventPath(Context.Path, 2));
               }
-              (primitives_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (primitives_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               primitives_  = global::Com.Zynga.Runtime.Protobuf.File.AllPrimitives.Parser.ParseFrom(e.Set.ByteData);
               primitives_.SetParent(Context, new EventPath(Context.Path, 2));
@@ -3102,7 +3123,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 bar_ = new global::Com.Zynga.Runtime.Protobuf.File.Bar();
                 bar_.SetParent(Context, new EventPath(Context.Path, 4));
               }
-              (bar_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (bar_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               bar_  = global::Com.Zynga.Runtime.Protobuf.File.Bar.Parser.ParseFrom(e.Set.ByteData);
               bar_.SetParent(Context, new EventPath(Context.Path, 4));

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/NoEventsTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/NoEventsTest.cs
@@ -166,7 +166,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class HasEvents : zpr::EventRegistry, pb::IMessage<HasEvents> {
+  public sealed partial class HasEvents : zpr::EventRegistry<HasEvents>, pb::IMessage<HasEvents> {
     private static readonly pb::MessageParser<HasEvents> _parser = new pb::MessageParser<HasEvents>(() => new HasEvents());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<HasEvents> Parser { get { return _parser; } }
@@ -199,6 +199,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override HasEvents Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -292,6 +294,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/AllTypesTests.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/AllTypesTests.cs
@@ -1,7 +1,8 @@
-﻿using Xunit;
+﻿using System.Collections.Generic;
+using Google.Protobuf.TestProtos;
+using Xunit;
 using static Zynga.Protobuf.Runtime.Tests.Simple.EventTestHelper;
 using static Zynga.Protobuf.Runtime.Tests.Simple.AllTypesTestsHelper;
-using Google.Protobuf.TestProtos;
 
 namespace Zynga.Protobuf.Runtime.Tests.Simple {
 	public class AllTypesTests {
@@ -451,8 +452,16 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 			allTypes.RepeatedBool.Add(false);
 			allTypes.MapStringString["foo"] = "bar";
 			events = allTypes.GenerateEvents();
-			target.RepeatedBool.OnChanged += f => { repeatedBoolChanged = true; };
-			target.MapStringString.OnChanged += f => { mapStringChanged = true; };
+			target.RepeatedBool.OnChanged += (f, changes) => {
+				repeatedBoolChanged = true;
+				Assert.Equal(1, changes.Count);
+				Assert.Equal(false, changes[0].Value);
+				Assert.Equal(1, changes[0].Index);  // initial RepeatedBool already has a single element
+			};
+			target.MapStringString.OnChanged += (f, changes) => {
+				mapStringChanged = true;
+				Assert.Equal(1, changes.Count);
+			};
 
 			target.ApplyEvents(events);
 
@@ -523,8 +532,16 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 			allTypes.RepeatedBool.Add(false);
 			allTypes.MapStringString["foo"] = "bar";
 			events = root.GenerateEvents();
-			target.RepeatedBool.OnChanged += f => { repeatedBoolChanged = true; };
-			target.MapStringString.OnChanged += f => { mapStringChanged = true; };
+			target.RepeatedBool.OnChanged += (f, changes) => {
+				repeatedBoolChanged = true;
+				Assert.Equal(1, changes.Count);
+				Assert.Equal(false, changes[0].Value);
+				Assert.Equal(1, changes[0].Index);  // initial RepeatedBool already has a single element
+			};
+			target.MapStringString.OnChanged += (f, changes) => {
+				mapStringChanged = true;
+				Assert.Equal(1, changes.Count);
+			};
 
 			targetAllTypes.ApplyEvents(events);
 
@@ -534,6 +551,128 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 			Assert.False(publicImportChanged);
 			Assert.True(repeatedBoolChanged);
 			Assert.True(mapStringChanged);
+		}
+
+		[Fact]
+		public void ShouldGenerateOnChangeListEvents() {
+			var allTypes = new TestAllTypes();
+			ApplyAllChanges(allTypes);
+			var snapshot = allTypes.GenerateSnapshot();
+
+			var target = new TestAllTypes();
+			target.ApplyEvents(snapshot);
+
+			// verify clearing generates an event, but doesn't generate any add/remove events
+			allTypes.RepeatedString.Clear();
+			var events = allTypes.GenerateEvents();
+			_validateListClearCalled = false;
+			target.RepeatedString.OnChanged += ValidateListClear;
+			target.ApplyEvents(events);
+			target.RepeatedString.OnChanged -= ValidateListClear;
+			Assert.True(_validateListClearCalled);
+
+			// verify add, remove, remove at, and insert generate valid events
+			allTypes.RepeatedString.Add("a"); // 1 event
+			allTypes.RepeatedString.Add("b"); // 1 event
+			allTypes.RepeatedString[0] = "c"; // 2 events
+			allTypes.RepeatedString.RemoveAt(0); // 1 event   (3 removes on these two lines)
+			allTypes.RepeatedString.Remove("b"); // 1 event
+			// should be empty
+			allTypes.RepeatedString.Add("e");  // 1 event
+			allTypes.RepeatedString.Insert(0, "f"); // 1 event
+
+			events = allTypes.GenerateEvents();
+			bool onChangeCalled = false;
+			target.RepeatedString.OnChanged += (list, changes) => {
+				onChangeCalled = true;
+				Assert.Equal(2, list.Count);
+				Assert.Equal(8, changes.Count);
+				Assert.Equal(0, changes[0].Index);
+				Assert.Equal(1, changes[1].Index);
+				Assert.Equal(0, changes[2].Index);
+				Assert.Equal(0, changes[3].Index);
+				Assert.Equal(0, changes[4].Index);
+				Assert.Equal(0, changes[5].Index);
+				Assert.Equal(0, changes[6].Index);
+				Assert.Equal(0, changes[7].Index);
+				Assert.Equal("a", changes[0].Value);
+				Assert.Equal("b", changes[1].Value);
+				Assert.Equal("a", changes[2].Value);
+				Assert.Equal("c", changes[3].Value);
+				Assert.Equal("c", changes[4].Value);
+				Assert.Equal("b", changes[5].Value);
+				Assert.Equal("e", changes[6].Value);
+				Assert.Equal("f", changes[7].Value);
+			};
+
+			target.ApplyEvents(events);
+
+			Assert.True(onChangeCalled);
+		}
+
+		private bool _validateListClearCalled;
+		private void ValidateListClear(EventRepeatedField<string> list, IReadOnlyList<EventListChange<string>> changes) {
+			_validateListClearCalled = true;
+			Assert.Equal(0, list.Count);
+			Assert.Equal(0, changes.Count);
+		}
+
+		[Fact]
+		public void ShouldGenerateOnChangeMapEvents() {
+			var allTypes = new TestAllTypes();
+			ApplyAllChanges(allTypes);
+			var snapshot = allTypes.GenerateSnapshot();
+
+			var target = new TestAllTypes();
+			target.ApplyEvents(snapshot);
+
+			// verify clearing generates an event, but doesn't generate any add/remove events
+			allTypes.MapStringString.Clear();
+			var events = allTypes.GenerateEvents();
+			_validateListClearCalled = false;
+			target.MapStringString.OnChanged += ValidateMapClear;
+			target.ApplyEvents(events);
+			target.MapStringString.OnChanged -= ValidateMapClear;
+			Assert.True(_validateMapClearCalled);
+
+			// verify add, remove, remove at, and insert generate valid events
+			allTypes.MapStringString.Add("a", "b"); // 1 event
+			allTypes.MapStringString.Add("c", "d"); // 1 event
+			allTypes.MapStringString["a"] = "e"; // 2 events
+			allTypes.MapStringString.Remove("a"); // 1 event
+			allTypes.MapStringString.Remove("c"); // 1 event
+			allTypes.MapStringString.Remove("d"); // 0 events
+
+			events = allTypes.GenerateEvents();
+			bool onChangeCalled = false;
+			target.MapStringString.OnChanged += (map, changes) => {
+				onChangeCalled = true;
+				Assert.Equal(0, map.Count);
+				Assert.Equal(6, changes.Count);
+				Assert.Equal("a", changes[0].Key);
+				Assert.Equal("b", changes[0].Value);
+				Assert.Equal("c", changes[1].Key);
+				Assert.Equal("d", changes[1].Value);
+				Assert.Equal("a", changes[2].Key);
+				Assert.Equal("b", changes[2].Value);
+				Assert.Equal("a", changes[3].Key);
+				Assert.Equal("e", changes[3].Value);
+				Assert.Equal("a", changes[4].Key);
+				Assert.Equal("e", changes[4].Value);
+				Assert.Equal("c", changes[5].Key);
+				Assert.Equal("d", changes[5].Value);
+			};
+
+			target.ApplyEvents(events);
+
+			Assert.True(onChangeCalled);
+		}
+
+		private bool _validateMapClearCalled;
+		private void ValidateMapClear(EventMapField<string, string> map, IReadOnlyList<EventMapChange<string, string>> changes) {
+			_validateMapClearCalled = true;
+			Assert.Equal(0, map.Count);
+			Assert.Equal(0, changes.Count);
 		}
 	}
 }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/EventTestHelper.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/EventTestHelper.cs
@@ -5,13 +5,13 @@ using Zynga.Protobuf.Runtime.EventSource;
 
 namespace Zynga.Protobuf.Runtime.Tests.Simple {
 	public static class EventTestHelper {
-		public static EventSourceRoot AssertGenerated(EventRegistry blob) {
+		public static EventSourceRoot AssertGenerated(IEventRegistry blob) {
 			EventSourceRoot root = blob.PeekEvents();
 			Assert.Single(root.Events);
 			return root;
 		}
 
-		public static void AssertNotGenerated(EventRegistry blob) {
+		public static void AssertNotGenerated(IEventRegistry blob) {
 			EventSourceRoot root = blob.PeekEvents();
 			Assert.Empty(root.Events);
 		}
@@ -23,20 +23,20 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 			}
 		}
 
-		public static void AssertDeltaPath(EventRegistry blob, int[] path) {
+		public static void AssertDeltaPath(IEventRegistry blob, int[] path) {
 			EventSourceRoot root = AssertGenerated(blob);
 			AssertPath(root.Events[0], path);
 			blob.ClearEvents();
 		}
 
-		public static void AssertEventsStable<T>(T message) where T : EventRegistry, IMessage, new() {
+		public static void AssertEventsStable<T>(T message) where T : IEventRegistry, IMessage, new() {
 			var newMessage = new T();
 			var events = message.GenerateEvents();
 			newMessage.ApplyEvents(events);
 			Assert.Equal(message, newMessage);
 		}
 
-		public static void AssertEventsStableWithClone<T>(T message, Action makeChanges, bool expectChanges = true) where T : EventRegistry, IMessage, IDeepCloneable<T>, new() {
+		public static void AssertEventsStableWithClone<T>(T message, Action makeChanges, bool expectChanges = true) where T : IEventRegistry, IMessage, IDeepCloneable<T>, new() {
 			if (message.HasEvents) {
 				message.ClearEvents();
 			}
@@ -58,7 +58,7 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 			Assert.Equal(message, newMessage);
 		}
 
-		public static void AssertEventsStableWithSnapshot<T>(T message, Action makeChanges, bool expectChanges = true) where T : EventRegistry, IMessage, IDeepCloneable<T>, new() {
+		public static void AssertEventsStableWithSnapshot<T>(T message, Action makeChanges, bool expectChanges = true) where T : IEventRegistry, IMessage, IDeepCloneable<T>, new() {
 			if (message.HasEvents) {
 				message.ClearEvents();
 			}

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleList.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleList.cs
@@ -198,7 +198,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class SimpleListDeltaMessage : zpr::EventRegistry, pb::IMessage<SimpleListDeltaMessage> {
+  public sealed partial class SimpleListDeltaMessage : zpr::EventRegistry<SimpleListDeltaMessage>, pb::IMessage<SimpleListDeltaMessage> {
     private static readonly pb::MessageParser<SimpleListDeltaMessage> _parser = new pb::MessageParser<SimpleListDeltaMessage>(() => new SimpleListDeltaMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<SimpleListDeltaMessage> Parser { get { return _parser; } }
@@ -231,6 +231,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override SimpleListDeltaMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -324,6 +326,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -465,7 +468,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class SimpleDeltaStringList : zpr::EventRegistry, pb::IMessage<SimpleDeltaStringList> {
+  public sealed partial class SimpleDeltaStringList : zpr::EventRegistry<SimpleDeltaStringList>, pb::IMessage<SimpleDeltaStringList> {
     private static readonly pb::MessageParser<SimpleDeltaStringList> _parser = new pb::MessageParser<SimpleDeltaStringList>(() => new SimpleDeltaStringList());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<SimpleDeltaStringList> Parser { get { return _parser; } }
@@ -500,6 +503,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override SimpleDeltaStringList Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -590,6 +595,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -732,7 +738,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class SimpleDeltaLongList : zpr::EventRegistry, pb::IMessage<SimpleDeltaLongList> {
+  public sealed partial class SimpleDeltaLongList : zpr::EventRegistry<SimpleDeltaLongList>, pb::IMessage<SimpleDeltaLongList> {
     private static readonly pb::MessageParser<SimpleDeltaLongList> _parser = new pb::MessageParser<SimpleDeltaLongList>(() => new SimpleDeltaLongList());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<SimpleDeltaLongList> Parser { get { return _parser; } }
@@ -767,6 +773,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override SimpleDeltaLongList Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -858,6 +866,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -1000,7 +1009,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class SimpleDeltaEnumList : zpr::EventRegistry, pb::IMessage<SimpleDeltaEnumList> {
+  public sealed partial class SimpleDeltaEnumList : zpr::EventRegistry<SimpleDeltaEnumList>, pb::IMessage<SimpleDeltaEnumList> {
     private static readonly pb::MessageParser<SimpleDeltaEnumList> _parser = new pb::MessageParser<SimpleDeltaEnumList>(() => new SimpleDeltaEnumList());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<SimpleDeltaEnumList> Parser { get { return _parser; } }
@@ -1035,6 +1044,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override SimpleDeltaEnumList Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -1126,6 +1137,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -1267,7 +1279,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class SimpleDeltaMessageList : zpr::EventRegistry, pb::IMessage<SimpleDeltaMessageList> {
+  public sealed partial class SimpleDeltaMessageList : zpr::EventRegistry<SimpleDeltaMessageList>, pb::IMessage<SimpleDeltaMessageList> {
     private static readonly pb::MessageParser<SimpleDeltaMessageList> _parser = new pb::MessageParser<SimpleDeltaMessageList>(() => new SimpleDeltaMessageList());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<SimpleDeltaMessageList> Parser { get { return _parser; } }
@@ -1302,6 +1314,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override SimpleDeltaMessageList Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -1393,6 +1407,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMap.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMap.cs
@@ -222,7 +222,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class SimpleMapDeltaMessage : zpr::EventRegistry, pb::IMessage<SimpleMapDeltaMessage> {
+  public sealed partial class SimpleMapDeltaMessage : zpr::EventRegistry<SimpleMapDeltaMessage>, pb::IMessage<SimpleMapDeltaMessage> {
     private static readonly pb::MessageParser<SimpleMapDeltaMessage> _parser = new pb::MessageParser<SimpleMapDeltaMessage>(() => new SimpleMapDeltaMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<SimpleMapDeltaMessage> Parser { get { return _parser; } }
@@ -255,6 +255,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override SimpleMapDeltaMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -348,6 +350,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -489,7 +492,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class SimpleLongToMessageDeltaMap : zpr::EventRegistry, pb::IMessage<SimpleLongToMessageDeltaMap> {
+  public sealed partial class SimpleLongToMessageDeltaMap : zpr::EventRegistry<SimpleLongToMessageDeltaMap>, pb::IMessage<SimpleLongToMessageDeltaMap> {
     private static readonly pb::MessageParser<SimpleLongToMessageDeltaMap> _parser = new pb::MessageParser<SimpleLongToMessageDeltaMap>(() => new SimpleLongToMessageDeltaMap());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<SimpleLongToMessageDeltaMap> Parser { get { return _parser; } }
@@ -524,6 +527,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override SimpleLongToMessageDeltaMap Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -629,6 +634,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -770,7 +776,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class SimpleStringToEnumDeltaMap : zpr::EventRegistry, pb::IMessage<SimpleStringToEnumDeltaMap> {
+  public sealed partial class SimpleStringToEnumDeltaMap : zpr::EventRegistry<SimpleStringToEnumDeltaMap>, pb::IMessage<SimpleStringToEnumDeltaMap> {
     private static readonly pb::MessageParser<SimpleStringToEnumDeltaMap> _parser = new pb::MessageParser<SimpleStringToEnumDeltaMap>(() => new SimpleStringToEnumDeltaMap());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<SimpleStringToEnumDeltaMap> Parser { get { return _parser; } }
@@ -805,6 +811,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override SimpleStringToEnumDeltaMap Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -909,6 +917,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -1050,7 +1059,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class SimpleStringToStringDeltaMap : zpr::EventRegistry, pb::IMessage<SimpleStringToStringDeltaMap> {
+  public sealed partial class SimpleStringToStringDeltaMap : zpr::EventRegistry<SimpleStringToStringDeltaMap>, pb::IMessage<SimpleStringToStringDeltaMap> {
     private static readonly pb::MessageParser<SimpleStringToStringDeltaMap> _parser = new pb::MessageParser<SimpleStringToStringDeltaMap>(() => new SimpleStringToStringDeltaMap());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<SimpleStringToStringDeltaMap> Parser { get { return _parser; } }
@@ -1085,6 +1094,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override SimpleStringToStringDeltaMap Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -1189,6 +1200,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -1330,7 +1342,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class SimpleStringToLongDeltaMap : zpr::EventRegistry, pb::IMessage<SimpleStringToLongDeltaMap> {
+  public sealed partial class SimpleStringToLongDeltaMap : zpr::EventRegistry<SimpleStringToLongDeltaMap>, pb::IMessage<SimpleStringToLongDeltaMap> {
     private static readonly pb::MessageParser<SimpleStringToLongDeltaMap> _parser = new pb::MessageParser<SimpleStringToLongDeltaMap>(() => new SimpleStringToLongDeltaMap());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<SimpleStringToLongDeltaMap> Parser { get { return _parser; } }
@@ -1365,6 +1377,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override SimpleStringToLongDeltaMap Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -1469,6 +1483,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
@@ -47,7 +47,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
   #region Messages
-  public sealed partial class ParentMessage : zpr::EventRegistry, pb::IMessage<ParentMessage> {
+  public sealed partial class ParentMessage : zpr::EventRegistry<ParentMessage>, pb::IMessage<ParentMessage> {
     private static readonly pb::MessageParser<ParentMessage> _parser = new pb::MessageParser<ParentMessage>(() => new ParentMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<ParentMessage> Parser { get { return _parser; } }
@@ -81,6 +81,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override ParentMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -216,6 +218,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -231,7 +234,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 b_ = new global::Com.Zynga.Runtime.Protobuf.ChildMessage();
                 b_.SetParent(Context, new EventPath(Context.Path, 2));
               }
-              (b_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (b_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               b_  = global::Com.Zynga.Runtime.Protobuf.ChildMessage.Parser.ParseFrom(e.Set.ByteData);
               b_.SetParent(Context, new EventPath(Context.Path, 2));
@@ -259,7 +262,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class ChildMessage : zpr::EventRegistry, pb::IMessage<ChildMessage> {
+  public sealed partial class ChildMessage : zpr::EventRegistry<ChildMessage>, pb::IMessage<ChildMessage> {
     private static readonly pb::MessageParser<ChildMessage> _parser = new pb::MessageParser<ChildMessage>(() => new ChildMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<ChildMessage> Parser { get { return _parser; } }
@@ -293,6 +296,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override ChildMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -428,6 +433,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -443,7 +449,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 d_ = new global::Com.Zynga.Runtime.Protobuf.ChildChildMessage();
                 d_.SetParent(Context, new EventPath(Context.Path, 4));
               }
-              (d_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (d_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               d_  = global::Com.Zynga.Runtime.Protobuf.ChildChildMessage.Parser.ParseFrom(e.Set.ByteData);
               d_.SetParent(Context, new EventPath(Context.Path, 4));
@@ -471,7 +477,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class ChildChildMessage : zpr::EventRegistry, pb::IMessage<ChildChildMessage> {
+  public sealed partial class ChildChildMessage : zpr::EventRegistry<ChildChildMessage>, pb::IMessage<ChildChildMessage> {
     private static readonly pb::MessageParser<ChildChildMessage> _parser = new pb::MessageParser<ChildChildMessage>(() => new ChildChildMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<ChildChildMessage> Parser { get { return _parser; } }
@@ -504,6 +510,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override ChildChildMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -597,6 +605,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/UnittestImportProto3.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/UnittestImportProto3.cs
@@ -57,7 +57,7 @@ namespace Google.Protobuf.TestProtos {
   #endregion
 
   #region Messages
-  public sealed partial class ImportMessage : zpr::EventRegistry, pb::IMessage<ImportMessage> {
+  public sealed partial class ImportMessage : zpr::EventRegistry<ImportMessage>, pb::IMessage<ImportMessage> {
     private static readonly pb::MessageParser<ImportMessage> _parser = new pb::MessageParser<ImportMessage>(() => new ImportMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<ImportMessage> Parser { get { return _parser; } }
@@ -90,6 +90,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override ImportMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -183,6 +185,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/UnittestImportPublicProto3.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/UnittestImportPublicProto3.cs
@@ -44,7 +44,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
   #region Messages
-  public sealed partial class PublicImportMessage : zpr::EventRegistry, pb::IMessage<PublicImportMessage> {
+  public sealed partial class PublicImportMessage : zpr::EventRegistry<PublicImportMessage>, pb::IMessage<PublicImportMessage> {
     private static readonly pb::MessageParser<PublicImportMessage> _parser = new pb::MessageParser<PublicImportMessage>(() => new PublicImportMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<PublicImportMessage> Parser { get { return _parser; } }
@@ -77,6 +77,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override PublicImportMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -170,6 +172,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/UnittestProto3.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/UnittestProto3.cs
@@ -749,7 +749,7 @@ namespace Google.Protobuf.TestProtos {
   /// This proto includes every type of field in both singular and repeated
   /// forms.
   /// </summary>
-  public sealed partial class TestAllTypes : zpr::EventRegistry, pb::IMessage<TestAllTypes> {
+  public sealed partial class TestAllTypes : zpr::EventRegistry<TestAllTypes>, pb::IMessage<TestAllTypes> {
     private static readonly pb::MessageParser<TestAllTypes> _parser = new pb::MessageParser<TestAllTypes>(() => new TestAllTypes());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestAllTypes> Parser { get { return _parser; } }
@@ -964,6 +964,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestAllTypes Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -3788,7 +3790,7 @@ namespace Google.Protobuf.TestProtos {
         [pbr::OriginalName("NEG")] Neg = -1,
       }
 
-      public sealed partial class NestedMessage : zpr::EventRegistry, pb::IMessage<NestedMessage> {
+      public sealed partial class NestedMessage : zpr::EventRegistry<NestedMessage>, pb::IMessage<NestedMessage> {
         private static readonly pb::MessageParser<NestedMessage> _parser = new pb::MessageParser<NestedMessage>(() => new NestedMessage());
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pb::MessageParser<NestedMessage> Parser { get { return _parser; } }
@@ -3821,6 +3823,8 @@ namespace Google.Protobuf.TestProtos {
         }
 
         public static bool IsEventSourced = true;
+
+        protected override NestedMessage Message { get{ return this; } }
 
         public override void SetParent(EventContext parent, EventPath path) {
           base.SetParent(parent, path);
@@ -3919,6 +3923,7 @@ namespace Google.Protobuf.TestProtos {
         }
 
         public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+            MarkDirty();
             if (e.Path.Count == 0) {
               this.MergeFrom(e.Set.ByteData);
               return true;
@@ -3953,6 +3958,7 @@ namespace Google.Protobuf.TestProtos {
     #endregion
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -4024,7 +4030,7 @@ namespace Google.Protobuf.TestProtos {
                 singleNestedMessage_ = new global::Google.Protobuf.TestProtos.TestAllTypes.Types.NestedMessage();
                 singleNestedMessage_.SetParent(Context, new EventPath(Context.Path, 18));
               }
-              (singleNestedMessage_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (singleNestedMessage_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               singleNestedMessage_  = global::Google.Protobuf.TestProtos.TestAllTypes.Types.NestedMessage.Parser.ParseFrom(e.Set.ByteData);
               singleNestedMessage_.SetParent(Context, new EventPath(Context.Path, 18));
@@ -4037,7 +4043,7 @@ namespace Google.Protobuf.TestProtos {
                 singleForeignMessage_ = new global::Google.Protobuf.TestProtos.ForeignMessage();
                 singleForeignMessage_.SetParent(Context, new EventPath(Context.Path, 19));
               }
-              (singleForeignMessage_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (singleForeignMessage_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               singleForeignMessage_  = global::Google.Protobuf.TestProtos.ForeignMessage.Parser.ParseFrom(e.Set.ByteData);
               singleForeignMessage_.SetParent(Context, new EventPath(Context.Path, 19));
@@ -4050,7 +4056,7 @@ namespace Google.Protobuf.TestProtos {
                 singleImportMessage_ = new global::Google.Protobuf.TestProtos.ImportMessage();
                 singleImportMessage_.SetParent(Context, new EventPath(Context.Path, 20));
               }
-              (singleImportMessage_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (singleImportMessage_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               singleImportMessage_  = global::Google.Protobuf.TestProtos.ImportMessage.Parser.ParseFrom(e.Set.ByteData);
               singleImportMessage_.SetParent(Context, new EventPath(Context.Path, 20));
@@ -4075,7 +4081,7 @@ namespace Google.Protobuf.TestProtos {
                 singlePublicImportMessage_ = new global::Google.Protobuf.TestProtos.PublicImportMessage();
                 singlePublicImportMessage_.SetParent(Context, new EventPath(Context.Path, 26));
               }
-              (singlePublicImportMessage_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (singlePublicImportMessage_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               singlePublicImportMessage_  = global::Google.Protobuf.TestProtos.PublicImportMessage.Parser.ParseFrom(e.Set.ByteData);
               singlePublicImportMessage_.SetParent(Context, new EventPath(Context.Path, 26));
@@ -4187,12 +4193,12 @@ namespace Google.Protobuf.TestProtos {
             if (e.Path.Count - 1 != pathIndex) {
               if (oneofField_ == null) {
                 oneofField_ = new global::Google.Protobuf.TestProtos.TestAllTypes.Types.NestedMessage();
-                (oneofField_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 112));
+                (oneofField_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 112));
               }
-              (oneofField_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (oneofField_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               oneofField_   = global::Google.Protobuf.TestProtos.TestAllTypes.Types.NestedMessage.Parser.ParseFrom(e.Set.ByteData);
-              (oneofField_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 112));
+              (oneofField_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 112));
             }
             oneofFieldCase_ = oneofField_ == null ? OneofFieldOneofCase.None : OneofFieldOneofCase.OneofNestedMessage;
           }
@@ -4211,12 +4217,12 @@ namespace Google.Protobuf.TestProtos {
             if (e.Path.Count - 1 != pathIndex) {
               if (oneofField_ == null) {
                 oneofField_ = new global::Google.Protobuf.TestProtos.ForeignMessage();
-                (oneofField_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 137));
+                (oneofField_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 137));
               }
-              (oneofField_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (oneofField_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               oneofField_   = global::Google.Protobuf.TestProtos.ForeignMessage.Parser.ParseFrom(e.Set.ByteData);
-              (oneofField_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 137));
+              (oneofField_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 137));
             }
             oneofFieldCase_ = oneofField_ == null ? OneofFieldOneofCase.None : OneofFieldOneofCase.OneofForeignMessage;
           }
@@ -4230,12 +4236,12 @@ namespace Google.Protobuf.TestProtos {
             if (e.Path.Count - 1 != pathIndex) {
               if (oneofField_ == null) {
                 oneofField_ = new global::Google.Protobuf.TestProtos.TestAllTypes();
-                (oneofField_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 139));
+                (oneofField_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 139));
               }
-              (oneofField_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (oneofField_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               oneofField_   = global::Google.Protobuf.TestProtos.TestAllTypes.Parser.ParseFrom(e.Set.ByteData);
-              (oneofField_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 139));
+              (oneofField_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 139));
             }
             oneofFieldCase_ = oneofField_ == null ? OneofFieldOneofCase.None : OneofFieldOneofCase.OneofAllTypes;
           }
@@ -4331,7 +4337,7 @@ namespace Google.Protobuf.TestProtos {
                 allTypes_ = new global::Google.Protobuf.TestProtos.TestAllTypes();
                 allTypes_.SetParent(Context, new EventPath(Context.Path, 135));
               }
-              (allTypes_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (allTypes_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               allTypes_  = global::Google.Protobuf.TestProtos.TestAllTypes.Parser.ParseFrom(e.Set.ByteData);
               allTypes_.SetParent(Context, new EventPath(Context.Path, 135));
@@ -4366,7 +4372,7 @@ namespace Google.Protobuf.TestProtos {
   /// <summary>
   /// This proto includes a recusively nested message.
   /// </summary>
-  public sealed partial class NestedTestAllTypes : zpr::EventRegistry, pb::IMessage<NestedTestAllTypes> {
+  public sealed partial class NestedTestAllTypes : zpr::EventRegistry<NestedTestAllTypes>, pb::IMessage<NestedTestAllTypes> {
     private static readonly pb::MessageParser<NestedTestAllTypes> _parser = new pb::MessageParser<NestedTestAllTypes>(() => new NestedTestAllTypes());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<NestedTestAllTypes> Parser { get { return _parser; } }
@@ -4403,6 +4409,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override NestedTestAllTypes Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -4578,6 +4586,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -4589,7 +4598,7 @@ namespace Google.Protobuf.TestProtos {
                 child_ = new global::Google.Protobuf.TestProtos.NestedTestAllTypes();
                 child_.SetParent(Context, new EventPath(Context.Path, 1));
               }
-              (child_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (child_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               child_  = global::Google.Protobuf.TestProtos.NestedTestAllTypes.Parser.ParseFrom(e.Set.ByteData);
               child_.SetParent(Context, new EventPath(Context.Path, 1));
@@ -4602,7 +4611,7 @@ namespace Google.Protobuf.TestProtos {
                 payload_ = new global::Google.Protobuf.TestProtos.TestAllTypes();
                 payload_.SetParent(Context, new EventPath(Context.Path, 2));
               }
-              (payload_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (payload_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               payload_  = global::Google.Protobuf.TestProtos.TestAllTypes.Parser.ParseFrom(e.Set.ByteData);
               payload_.SetParent(Context, new EventPath(Context.Path, 2));
@@ -4634,7 +4643,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class TestDeprecatedFields : zpr::EventRegistry, pb::IMessage<TestDeprecatedFields> {
+  public sealed partial class TestDeprecatedFields : zpr::EventRegistry<TestDeprecatedFields>, pb::IMessage<TestDeprecatedFields> {
     private static readonly pb::MessageParser<TestDeprecatedFields> _parser = new pb::MessageParser<TestDeprecatedFields>(() => new TestDeprecatedFields());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestDeprecatedFields> Parser { get { return _parser; } }
@@ -4667,6 +4676,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestDeprecatedFields Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -4761,6 +4772,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -4795,7 +4807,7 @@ namespace Google.Protobuf.TestProtos {
   /// Define these after TestAllTypes to make sure the compiler can handle
   /// that.
   /// </summary>
-  public sealed partial class ForeignMessage : zpr::EventRegistry, pb::IMessage<ForeignMessage> {
+  public sealed partial class ForeignMessage : zpr::EventRegistry<ForeignMessage>, pb::IMessage<ForeignMessage> {
     private static readonly pb::MessageParser<ForeignMessage> _parser = new pb::MessageParser<ForeignMessage>(() => new ForeignMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<ForeignMessage> Parser { get { return _parser; } }
@@ -4828,6 +4840,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override ForeignMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -4921,6 +4935,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -4951,7 +4966,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class TestReservedFields : zpr::EventRegistry, pb::IMessage<TestReservedFields> {
+  public sealed partial class TestReservedFields : zpr::EventRegistry<TestReservedFields>, pb::IMessage<TestReservedFields> {
     private static readonly pb::MessageParser<TestReservedFields> _parser = new pb::MessageParser<TestReservedFields>(() => new TestReservedFields());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestReservedFields> Parser { get { return _parser; } }
@@ -4983,6 +4998,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestReservedFields Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -5044,6 +5061,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -5073,7 +5091,7 @@ namespace Google.Protobuf.TestProtos {
   /// <summary>
   /// Test that we can use NestedMessage from outside TestAllTypes.
   /// </summary>
-  public sealed partial class TestForeignNested : zpr::EventRegistry, pb::IMessage<TestForeignNested> {
+  public sealed partial class TestForeignNested : zpr::EventRegistry<TestForeignNested>, pb::IMessage<TestForeignNested> {
     private static readonly pb::MessageParser<TestForeignNested> _parser = new pb::MessageParser<TestForeignNested>(() => new TestForeignNested());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestForeignNested> Parser { get { return _parser; } }
@@ -5106,6 +5124,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestForeignNested Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -5209,6 +5229,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -5220,7 +5241,7 @@ namespace Google.Protobuf.TestProtos {
                 foreignNested_ = new global::Google.Protobuf.TestProtos.TestAllTypes.Types.NestedMessage();
                 foreignNested_.SetParent(Context, new EventPath(Context.Path, 1));
               }
-              (foreignNested_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (foreignNested_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               foreignNested_  = global::Google.Protobuf.TestProtos.TestAllTypes.Types.NestedMessage.Parser.ParseFrom(e.Set.ByteData);
               foreignNested_.SetParent(Context, new EventPath(Context.Path, 1));
@@ -5251,7 +5272,7 @@ namespace Google.Protobuf.TestProtos {
   /// <summary>
   /// Test that really large tag numbers don't break anything.
   /// </summary>
-  public sealed partial class TestReallyLargeTagNumber : zpr::EventRegistry, pb::IMessage<TestReallyLargeTagNumber> {
+  public sealed partial class TestReallyLargeTagNumber : zpr::EventRegistry<TestReallyLargeTagNumber>, pb::IMessage<TestReallyLargeTagNumber> {
     private static readonly pb::MessageParser<TestReallyLargeTagNumber> _parser = new pb::MessageParser<TestReallyLargeTagNumber>(() => new TestReallyLargeTagNumber());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestReallyLargeTagNumber> Parser { get { return _parser; } }
@@ -5285,6 +5306,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestReallyLargeTagNumber Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -5414,6 +5437,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -5448,7 +5472,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class TestRecursiveMessage : zpr::EventRegistry, pb::IMessage<TestRecursiveMessage> {
+  public sealed partial class TestRecursiveMessage : zpr::EventRegistry<TestRecursiveMessage>, pb::IMessage<TestRecursiveMessage> {
     private static readonly pb::MessageParser<TestRecursiveMessage> _parser = new pb::MessageParser<TestRecursiveMessage>(() => new TestRecursiveMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestRecursiveMessage> Parser { get { return _parser; } }
@@ -5482,6 +5506,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestRecursiveMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -5617,6 +5643,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -5628,7 +5655,7 @@ namespace Google.Protobuf.TestProtos {
                 a_ = new global::Google.Protobuf.TestProtos.TestRecursiveMessage();
                 a_.SetParent(Context, new EventPath(Context.Path, 1));
               }
-              (a_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (a_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               a_  = global::Google.Protobuf.TestProtos.TestRecursiveMessage.Parser.ParseFrom(e.Set.ByteData);
               a_.SetParent(Context, new EventPath(Context.Path, 1));
@@ -5663,7 +5690,7 @@ namespace Google.Protobuf.TestProtos {
   /// <summary>
   /// Test that mutual recursion works.
   /// </summary>
-  public sealed partial class TestMutualRecursionA : zpr::EventRegistry, pb::IMessage<TestMutualRecursionA> {
+  public sealed partial class TestMutualRecursionA : zpr::EventRegistry<TestMutualRecursionA>, pb::IMessage<TestMutualRecursionA> {
     private static readonly pb::MessageParser<TestMutualRecursionA> _parser = new pb::MessageParser<TestMutualRecursionA>(() => new TestMutualRecursionA());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestMutualRecursionA> Parser { get { return _parser; } }
@@ -5696,6 +5723,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestMutualRecursionA Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -5799,6 +5828,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -5810,7 +5840,7 @@ namespace Google.Protobuf.TestProtos {
                 bb_ = new global::Google.Protobuf.TestProtos.TestMutualRecursionB();
                 bb_.SetParent(Context, new EventPath(Context.Path, 1));
               }
-              (bb_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (bb_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               bb_  = global::Google.Protobuf.TestProtos.TestMutualRecursionB.Parser.ParseFrom(e.Set.ByteData);
               bb_.SetParent(Context, new EventPath(Context.Path, 1));
@@ -5838,7 +5868,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class TestMutualRecursionB : zpr::EventRegistry, pb::IMessage<TestMutualRecursionB> {
+  public sealed partial class TestMutualRecursionB : zpr::EventRegistry<TestMutualRecursionB>, pb::IMessage<TestMutualRecursionB> {
     private static readonly pb::MessageParser<TestMutualRecursionB> _parser = new pb::MessageParser<TestMutualRecursionB>(() => new TestMutualRecursionB());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestMutualRecursionB> Parser { get { return _parser; } }
@@ -5872,6 +5902,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestMutualRecursionB Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -6007,6 +6039,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -6018,7 +6051,7 @@ namespace Google.Protobuf.TestProtos {
                 a_ = new global::Google.Protobuf.TestProtos.TestMutualRecursionA();
                 a_.SetParent(Context, new EventPath(Context.Path, 1));
               }
-              (a_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (a_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               a_  = global::Google.Protobuf.TestProtos.TestMutualRecursionA.Parser.ParseFrom(e.Set.ByteData);
               a_.SetParent(Context, new EventPath(Context.Path, 1));
@@ -6050,7 +6083,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class TestEnumAllowAlias : zpr::EventRegistry, pb::IMessage<TestEnumAllowAlias> {
+  public sealed partial class TestEnumAllowAlias : zpr::EventRegistry<TestEnumAllowAlias>, pb::IMessage<TestEnumAllowAlias> {
     private static readonly pb::MessageParser<TestEnumAllowAlias> _parser = new pb::MessageParser<TestEnumAllowAlias>(() => new TestEnumAllowAlias());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestEnumAllowAlias> Parser { get { return _parser; } }
@@ -6083,6 +6116,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestEnumAllowAlias Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -6176,6 +6211,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -6210,7 +6246,7 @@ namespace Google.Protobuf.TestProtos {
   /// Test message with CamelCase field names.  This violates Protocol Buffer
   /// standard style.
   /// </summary>
-  public sealed partial class TestCamelCaseFieldNames : zpr::EventRegistry, pb::IMessage<TestCamelCaseFieldNames> {
+  public sealed partial class TestCamelCaseFieldNames : zpr::EventRegistry<TestCamelCaseFieldNames>, pb::IMessage<TestCamelCaseFieldNames> {
     private static readonly pb::MessageParser<TestCamelCaseFieldNames> _parser = new pb::MessageParser<TestCamelCaseFieldNames>(() => new TestCamelCaseFieldNames());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestCamelCaseFieldNames> Parser { get { return _parser; } }
@@ -6258,6 +6294,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestCamelCaseFieldNames Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -6576,6 +6614,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -6599,7 +6638,7 @@ namespace Google.Protobuf.TestProtos {
                 messageField_ = new global::Google.Protobuf.TestProtos.ForeignMessage();
                 messageField_.SetParent(Context, new EventPath(Context.Path, 4));
               }
-              (messageField_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (messageField_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               messageField_  = global::Google.Protobuf.TestProtos.ForeignMessage.Parser.ParseFrom(e.Set.ByteData);
               messageField_.SetParent(Context, new EventPath(Context.Path, 4));
@@ -6647,7 +6686,7 @@ namespace Google.Protobuf.TestProtos {
   /// We list fields out of order, to ensure that we're using field number and not
   /// field index to determine serialization order.
   /// </summary>
-  public sealed partial class TestFieldOrderings : zpr::EventRegistry, pb::IMessage<TestFieldOrderings> {
+  public sealed partial class TestFieldOrderings : zpr::EventRegistry<TestFieldOrderings>, pb::IMessage<TestFieldOrderings> {
     private static readonly pb::MessageParser<TestFieldOrderings> _parser = new pb::MessageParser<TestFieldOrderings>(() => new TestFieldOrderings());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestFieldOrderings> Parser { get { return _parser; } }
@@ -6683,6 +6722,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestFieldOrderings Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -6885,7 +6926,7 @@ namespace Google.Protobuf.TestProtos {
     /// <summary>Container for nested types declared in the TestFieldOrderings message type.</summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static partial class Types {
-      public sealed partial class NestedMessage : zpr::EventRegistry, pb::IMessage<NestedMessage> {
+      public sealed partial class NestedMessage : zpr::EventRegistry<NestedMessage>, pb::IMessage<NestedMessage> {
         private static readonly pb::MessageParser<NestedMessage> _parser = new pb::MessageParser<NestedMessage>(() => new NestedMessage());
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
         public static pb::MessageParser<NestedMessage> Parser { get { return _parser; } }
@@ -6919,6 +6960,8 @@ namespace Google.Protobuf.TestProtos {
         }
 
         public static bool IsEventSourced = true;
+
+        protected override NestedMessage Message { get{ return this; } }
 
         public override void SetParent(EventContext parent, EventPath path) {
           base.SetParent(parent, path);
@@ -7049,6 +7092,7 @@ namespace Google.Protobuf.TestProtos {
         }
 
         public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+            MarkDirty();
             if (e.Path.Count == 0) {
               this.MergeFrom(e.Set.ByteData);
               return true;
@@ -7087,6 +7131,7 @@ namespace Google.Protobuf.TestProtos {
     #endregion
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -7110,7 +7155,7 @@ namespace Google.Protobuf.TestProtos {
                 singleNestedMessage_ = new global::Google.Protobuf.TestProtos.TestFieldOrderings.Types.NestedMessage();
                 singleNestedMessage_.SetParent(Context, new EventPath(Context.Path, 200));
               }
-              (singleNestedMessage_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (singleNestedMessage_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               singleNestedMessage_  = global::Google.Protobuf.TestProtos.TestFieldOrderings.Types.NestedMessage.Parser.ParseFrom(e.Set.ByteData);
               singleNestedMessage_.SetParent(Context, new EventPath(Context.Path, 200));
@@ -7138,7 +7183,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class SparseEnumMessage : zpr::EventRegistry, pb::IMessage<SparseEnumMessage> {
+  public sealed partial class SparseEnumMessage : zpr::EventRegistry<SparseEnumMessage>, pb::IMessage<SparseEnumMessage> {
     private static readonly pb::MessageParser<SparseEnumMessage> _parser = new pb::MessageParser<SparseEnumMessage>(() => new SparseEnumMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<SparseEnumMessage> Parser { get { return _parser; } }
@@ -7171,6 +7216,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override SparseEnumMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -7264,6 +7311,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -7297,7 +7345,7 @@ namespace Google.Protobuf.TestProtos {
   /// <summary>
   /// Test String and Bytes: string is for valid UTF-8 strings
   /// </summary>
-  public sealed partial class OneString : zpr::EventRegistry, pb::IMessage<OneString> {
+  public sealed partial class OneString : zpr::EventRegistry<OneString>, pb::IMessage<OneString> {
     private static readonly pb::MessageParser<OneString> _parser = new pb::MessageParser<OneString>(() => new OneString());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<OneString> Parser { get { return _parser; } }
@@ -7330,6 +7378,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override OneString Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -7423,6 +7473,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -7453,7 +7504,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class MoreString : zpr::EventRegistry, pb::IMessage<MoreString> {
+  public sealed partial class MoreString : zpr::EventRegistry<MoreString>, pb::IMessage<MoreString> {
     private static readonly pb::MessageParser<MoreString> _parser = new pb::MessageParser<MoreString>(() => new MoreString());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<MoreString> Parser { get { return _parser; } }
@@ -7488,6 +7539,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override MoreString Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -7578,6 +7631,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -7608,7 +7662,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class OneBytes : zpr::EventRegistry, pb::IMessage<OneBytes> {
+  public sealed partial class OneBytes : zpr::EventRegistry<OneBytes>, pb::IMessage<OneBytes> {
     private static readonly pb::MessageParser<OneBytes> _parser = new pb::MessageParser<OneBytes>(() => new OneBytes());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<OneBytes> Parser { get { return _parser; } }
@@ -7641,6 +7695,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override OneBytes Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -7734,6 +7790,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -7764,7 +7821,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class MoreBytes : zpr::EventRegistry, pb::IMessage<MoreBytes> {
+  public sealed partial class MoreBytes : zpr::EventRegistry<MoreBytes>, pb::IMessage<MoreBytes> {
     private static readonly pb::MessageParser<MoreBytes> _parser = new pb::MessageParser<MoreBytes>(() => new MoreBytes());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<MoreBytes> Parser { get { return _parser; } }
@@ -7797,6 +7854,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override MoreBytes Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -7890,6 +7949,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -7923,7 +7983,7 @@ namespace Google.Protobuf.TestProtos {
   /// <summary>
   /// Test int32, uint32, int64, uint64, and bool are all compatible
   /// </summary>
-  public sealed partial class Int32Message : zpr::EventRegistry, pb::IMessage<Int32Message> {
+  public sealed partial class Int32Message : zpr::EventRegistry<Int32Message>, pb::IMessage<Int32Message> {
     private static readonly pb::MessageParser<Int32Message> _parser = new pb::MessageParser<Int32Message>(() => new Int32Message());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<Int32Message> Parser { get { return _parser; } }
@@ -7956,6 +8016,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override Int32Message Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -8049,6 +8111,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -8079,7 +8142,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class Uint32Message : zpr::EventRegistry, pb::IMessage<Uint32Message> {
+  public sealed partial class Uint32Message : zpr::EventRegistry<Uint32Message>, pb::IMessage<Uint32Message> {
     private static readonly pb::MessageParser<Uint32Message> _parser = new pb::MessageParser<Uint32Message>(() => new Uint32Message());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<Uint32Message> Parser { get { return _parser; } }
@@ -8112,6 +8175,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override Uint32Message Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -8205,6 +8270,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -8235,7 +8301,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class Int64Message : zpr::EventRegistry, pb::IMessage<Int64Message> {
+  public sealed partial class Int64Message : zpr::EventRegistry<Int64Message>, pb::IMessage<Int64Message> {
     private static readonly pb::MessageParser<Int64Message> _parser = new pb::MessageParser<Int64Message>(() => new Int64Message());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<Int64Message> Parser { get { return _parser; } }
@@ -8268,6 +8334,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override Int64Message Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -8361,6 +8429,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -8391,7 +8460,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class Uint64Message : zpr::EventRegistry, pb::IMessage<Uint64Message> {
+  public sealed partial class Uint64Message : zpr::EventRegistry<Uint64Message>, pb::IMessage<Uint64Message> {
     private static readonly pb::MessageParser<Uint64Message> _parser = new pb::MessageParser<Uint64Message>(() => new Uint64Message());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<Uint64Message> Parser { get { return _parser; } }
@@ -8424,6 +8493,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override Uint64Message Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -8517,6 +8588,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -8547,7 +8619,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class BoolMessage : zpr::EventRegistry, pb::IMessage<BoolMessage> {
+  public sealed partial class BoolMessage : zpr::EventRegistry<BoolMessage>, pb::IMessage<BoolMessage> {
     private static readonly pb::MessageParser<BoolMessage> _parser = new pb::MessageParser<BoolMessage>(() => new BoolMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<BoolMessage> Parser { get { return _parser; } }
@@ -8580,6 +8652,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override BoolMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -8673,6 +8747,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -8706,7 +8781,7 @@ namespace Google.Protobuf.TestProtos {
   /// <summary>
   /// Test oneofs.
   /// </summary>
-  public sealed partial class TestOneof : zpr::EventRegistry, pb::IMessage<TestOneof> {
+  public sealed partial class TestOneof : zpr::EventRegistry<TestOneof>, pb::IMessage<TestOneof> {
     private static readonly pb::MessageParser<TestOneof> _parser = new pb::MessageParser<TestOneof>(() => new TestOneof());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestOneof> Parser { get { return _parser; } }
@@ -8750,6 +8825,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestOneof Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -8942,6 +9019,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -8961,12 +9039,12 @@ namespace Google.Protobuf.TestProtos {
             if (e.Path.Count - 1 != pathIndex) {
               if (foo_ == null) {
                 foo_ = new global::Google.Protobuf.TestProtos.TestAllTypes();
-                (foo_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 3));
+                (foo_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 3));
               }
-              (foo_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (foo_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               foo_   = global::Google.Protobuf.TestProtos.TestAllTypes.Parser.ParseFrom(e.Set.ByteData);
-              (foo_ as zpr::EventRegistry)?.SetParent(Context, new EventPath(Context.Path, 3));
+              (foo_ as zpr::IEventRegistry)?.SetParent(Context, new EventPath(Context.Path, 3));
             }
             fooCase_ = foo_ == null ? FooOneofCase.None : FooOneofCase.FooMessage;
           }
@@ -8992,7 +9070,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class TestPackedTypes : zpr::EventRegistry, pb::IMessage<TestPackedTypes> {
+  public sealed partial class TestPackedTypes : zpr::EventRegistry<TestPackedTypes>, pb::IMessage<TestPackedTypes> {
     private static readonly pb::MessageParser<TestPackedTypes> _parser = new pb::MessageParser<TestPackedTypes>(() => new TestPackedTypes());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestPackedTypes> Parser { get { return _parser; } }
@@ -9066,6 +9144,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestPackedTypes Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -9547,6 +9627,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -9633,7 +9714,7 @@ namespace Google.Protobuf.TestProtos {
   /// A message with the same fields as TestPackedTypes, but without packing. Used
   /// to test packed &lt;-> unpacked wire compatibility.
   /// </summary>
-  public sealed partial class TestUnpackedTypes : zpr::EventRegistry, pb::IMessage<TestUnpackedTypes> {
+  public sealed partial class TestUnpackedTypes : zpr::EventRegistry<TestUnpackedTypes>, pb::IMessage<TestUnpackedTypes> {
     private static readonly pb::MessageParser<TestUnpackedTypes> _parser = new pb::MessageParser<TestUnpackedTypes>(() => new TestUnpackedTypes());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestUnpackedTypes> Parser { get { return _parser; } }
@@ -9707,6 +9788,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestUnpackedTypes Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -10188,6 +10271,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -10270,7 +10354,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class TestRepeatedScalarDifferentTagSizes : zpr::EventRegistry, pb::IMessage<TestRepeatedScalarDifferentTagSizes> {
+  public sealed partial class TestRepeatedScalarDifferentTagSizes : zpr::EventRegistry<TestRepeatedScalarDifferentTagSizes>, pb::IMessage<TestRepeatedScalarDifferentTagSizes> {
     private static readonly pb::MessageParser<TestRepeatedScalarDifferentTagSizes> _parser = new pb::MessageParser<TestRepeatedScalarDifferentTagSizes>(() => new TestRepeatedScalarDifferentTagSizes());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestRepeatedScalarDifferentTagSizes> Parser { get { return _parser; } }
@@ -10320,6 +10404,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestRepeatedScalarDifferentTagSizes Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -10575,6 +10661,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -10625,7 +10712,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class TestCommentInjectionMessage : zpr::EventRegistry, pb::IMessage<TestCommentInjectionMessage> {
+  public sealed partial class TestCommentInjectionMessage : zpr::EventRegistry<TestCommentInjectionMessage>, pb::IMessage<TestCommentInjectionMessage> {
     private static readonly pb::MessageParser<TestCommentInjectionMessage> _parser = new pb::MessageParser<TestCommentInjectionMessage>(() => new TestCommentInjectionMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestCommentInjectionMessage> Parser { get { return _parser; } }
@@ -10658,6 +10745,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestCommentInjectionMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -10754,6 +10843,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -10787,7 +10877,7 @@ namespace Google.Protobuf.TestProtos {
   /// <summary>
   /// Test that RPC services work.
   /// </summary>
-  public sealed partial class FooRequest : zpr::EventRegistry, pb::IMessage<FooRequest> {
+  public sealed partial class FooRequest : zpr::EventRegistry<FooRequest>, pb::IMessage<FooRequest> {
     private static readonly pb::MessageParser<FooRequest> _parser = new pb::MessageParser<FooRequest>(() => new FooRequest());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<FooRequest> Parser { get { return _parser; } }
@@ -10819,6 +10909,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override FooRequest Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -10880,6 +10972,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -10906,7 +10999,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class FooResponse : zpr::EventRegistry, pb::IMessage<FooResponse> {
+  public sealed partial class FooResponse : zpr::EventRegistry<FooResponse>, pb::IMessage<FooResponse> {
     private static readonly pb::MessageParser<FooResponse> _parser = new pb::MessageParser<FooResponse>(() => new FooResponse());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<FooResponse> Parser { get { return _parser; } }
@@ -10938,6 +11031,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override FooResponse Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -10999,6 +11094,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -11025,7 +11121,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class FooClientMessage : zpr::EventRegistry, pb::IMessage<FooClientMessage> {
+  public sealed partial class FooClientMessage : zpr::EventRegistry<FooClientMessage>, pb::IMessage<FooClientMessage> {
     private static readonly pb::MessageParser<FooClientMessage> _parser = new pb::MessageParser<FooClientMessage>(() => new FooClientMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<FooClientMessage> Parser { get { return _parser; } }
@@ -11057,6 +11153,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override FooClientMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -11118,6 +11216,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -11144,7 +11243,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class FooServerMessage : zpr::EventRegistry, pb::IMessage<FooServerMessage> {
+  public sealed partial class FooServerMessage : zpr::EventRegistry<FooServerMessage>, pb::IMessage<FooServerMessage> {
     private static readonly pb::MessageParser<FooServerMessage> _parser = new pb::MessageParser<FooServerMessage>(() => new FooServerMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<FooServerMessage> Parser { get { return _parser; } }
@@ -11176,6 +11275,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override FooServerMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -11237,6 +11338,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -11263,7 +11365,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class BarRequest : zpr::EventRegistry, pb::IMessage<BarRequest> {
+  public sealed partial class BarRequest : zpr::EventRegistry<BarRequest>, pb::IMessage<BarRequest> {
     private static readonly pb::MessageParser<BarRequest> _parser = new pb::MessageParser<BarRequest>(() => new BarRequest());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<BarRequest> Parser { get { return _parser; } }
@@ -11295,6 +11397,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override BarRequest Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -11356,6 +11460,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -11382,7 +11487,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class BarResponse : zpr::EventRegistry, pb::IMessage<BarResponse> {
+  public sealed partial class BarResponse : zpr::EventRegistry<BarResponse>, pb::IMessage<BarResponse> {
     private static readonly pb::MessageParser<BarResponse> _parser = new pb::MessageParser<BarResponse>(() => new BarResponse());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<BarResponse> Parser { get { return _parser; } }
@@ -11414,6 +11519,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override BarResponse Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -11475,6 +11582,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -11501,7 +11609,7 @@ namespace Google.Protobuf.TestProtos {
 
   }
 
-  public sealed partial class TestEmptyMessage : zpr::EventRegistry, pb::IMessage<TestEmptyMessage> {
+  public sealed partial class TestEmptyMessage : zpr::EventRegistry<TestEmptyMessage>, pb::IMessage<TestEmptyMessage> {
     private static readonly pb::MessageParser<TestEmptyMessage> _parser = new pb::MessageParser<TestEmptyMessage>(() => new TestEmptyMessage());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<TestEmptyMessage> Parser { get { return _parser; } }
@@ -11533,6 +11641,8 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override TestEmptyMessage Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -11594,6 +11704,7 @@ namespace Google.Protobuf.TestProtos {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/UpgradeTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/UpgradeTest.cs
@@ -103,7 +103,7 @@ namespace Com.Zynga.Runtime.Protobuf {
   #endregion
 
   #region Messages
-  public sealed partial class NestedMessage1 : zpr::EventRegistry, pb::IMessage<NestedMessage1> {
+  public sealed partial class NestedMessage1 : zpr::EventRegistry<NestedMessage1>, pb::IMessage<NestedMessage1> {
     private static readonly pb::MessageParser<NestedMessage1> _parser = new pb::MessageParser<NestedMessage1>(() => new NestedMessage1());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<NestedMessage1> Parser { get { return _parser; } }
@@ -136,6 +136,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override NestedMessage1 Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -229,6 +231,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -259,7 +262,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class NestedMessage2 : zpr::EventRegistry, pb::IMessage<NestedMessage2> {
+  public sealed partial class NestedMessage2 : zpr::EventRegistry<NestedMessage2>, pb::IMessage<NestedMessage2> {
     private static readonly pb::MessageParser<NestedMessage2> _parser = new pb::MessageParser<NestedMessage2>(() => new NestedMessage2());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<NestedMessage2> Parser { get { return _parser; } }
@@ -293,6 +296,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override NestedMessage2 Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -418,6 +423,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -452,7 +458,7 @@ namespace Com.Zynga.Runtime.Protobuf {
 
   }
 
-  public sealed partial class UpgradeMessage1 : zpr::EventRegistry, pb::IMessage<UpgradeMessage1> {
+  public sealed partial class UpgradeMessage1 : zpr::EventRegistry<UpgradeMessage1>, pb::IMessage<UpgradeMessage1> {
     private static readonly pb::MessageParser<UpgradeMessage1> _parser = new pb::MessageParser<UpgradeMessage1>(() => new UpgradeMessage1());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<UpgradeMessage1> Parser { get { return _parser; } }
@@ -500,6 +506,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override UpgradeMessage1 Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -826,6 +834,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -849,7 +858,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 nestedA_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage1();
                 nestedA_.SetParent(Context, new EventPath(Context.Path, 4));
               }
-              (nestedA_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (nestedA_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               nestedA_  = global::Com.Zynga.Runtime.Protobuf.NestedMessage1.Parser.ParseFrom(e.Set.ByteData);
               nestedA_.SetParent(Context, new EventPath(Context.Path, 4));
@@ -893,7 +902,7 @@ namespace Com.Zynga.Runtime.Protobuf {
   /// <summary>
   /// just re-name fields
   /// </summary>
-  public sealed partial class UpgradeMessage2 : zpr::EventRegistry, pb::IMessage<UpgradeMessage2> {
+  public sealed partial class UpgradeMessage2 : zpr::EventRegistry<UpgradeMessage2>, pb::IMessage<UpgradeMessage2> {
     private static readonly pb::MessageParser<UpgradeMessage2> _parser = new pb::MessageParser<UpgradeMessage2>(() => new UpgradeMessage2());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<UpgradeMessage2> Parser { get { return _parser; } }
@@ -941,6 +950,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override UpgradeMessage2 Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -1267,6 +1278,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -1290,7 +1302,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 nestedB_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage1();
                 nestedB_.SetParent(Context, new EventPath(Context.Path, 4));
               }
-              (nestedB_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (nestedB_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               nestedB_  = global::Com.Zynga.Runtime.Protobuf.NestedMessage1.Parser.ParseFrom(e.Set.ByteData);
               nestedB_.SetParent(Context, new EventPath(Context.Path, 4));
@@ -1334,7 +1346,7 @@ namespace Com.Zynga.Runtime.Protobuf {
   /// <summary>
   /// add a few fields
   /// </summary>
-  public sealed partial class UpgradeMessage3 : zpr::EventRegistry, pb::IMessage<UpgradeMessage3> {
+  public sealed partial class UpgradeMessage3 : zpr::EventRegistry<UpgradeMessage3>, pb::IMessage<UpgradeMessage3> {
     private static readonly pb::MessageParser<UpgradeMessage3> _parser = new pb::MessageParser<UpgradeMessage3>(() => new UpgradeMessage3());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<UpgradeMessage3> Parser { get { return _parser; } }
@@ -1386,6 +1398,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override UpgradeMessage3 Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -1777,6 +1791,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -1800,7 +1815,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 nestedB_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage2();
                 nestedB_.SetParent(Context, new EventPath(Context.Path, 4));
               }
-              (nestedB_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (nestedB_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               nestedB_  = global::Com.Zynga.Runtime.Protobuf.NestedMessage2.Parser.ParseFrom(e.Set.ByteData);
               nestedB_.SetParent(Context, new EventPath(Context.Path, 4));
@@ -1853,7 +1868,7 @@ namespace Com.Zynga.Runtime.Protobuf {
   /// <summary>
   /// remove a few fields
   /// </summary>
-  public sealed partial class UpgradeMessage4 : zpr::EventRegistry, pb::IMessage<UpgradeMessage4> {
+  public sealed partial class UpgradeMessage4 : zpr::EventRegistry<UpgradeMessage4>, pb::IMessage<UpgradeMessage4> {
     private static readonly pb::MessageParser<UpgradeMessage4> _parser = new pb::MessageParser<UpgradeMessage4>(() => new UpgradeMessage4());
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public static pb::MessageParser<UpgradeMessage4> Parser { get { return _parser; } }
@@ -1901,6 +1916,8 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public static bool IsEventSourced = true;
+
+    protected override UpgradeMessage4 Message { get{ return this; } }
 
     public override void SetParent(EventContext parent, EventPath path) {
       base.SetParent(parent, path);
@@ -2227,6 +2244,7 @@ namespace Com.Zynga.Runtime.Protobuf {
     }
 
     public override bool ApplyEvent(zpr.EventSource.EventData e, int pathIndex) {
+        MarkDirty();
         if (e.Path.Count == 0) {
           this.MergeFrom(e.Set.ByteData);
           return true;
@@ -2246,7 +2264,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 nestedB_ = new global::Com.Zynga.Runtime.Protobuf.NestedMessage2();
                 nestedB_.SetParent(Context, new EventPath(Context.Path, 4));
               }
-              (nestedB_ as zpr::EventRegistry)?.ApplyEvent(e, pathIndex + 1);
+              (nestedB_ as zpr::IEventRegistry)?.ApplyEvent(e, pathIndex + 1);
             } else {
               nestedB_  = global::Com.Zynga.Runtime.Protobuf.NestedMessage2.Parser.ParseFrom(e.Set.ByteData);
               nestedB_.SetParent(Context, new EventPath(Context.Path, 4));

--- a/runtime/src/Zynga.Protobuf.Runtime/EventChange.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventChange.cs
@@ -1,0 +1,74 @@
+﻿namespace Zynga.Protobuf.Runtime {
+	/// <summary>
+	/// Type of change event
+	/// </summary>
+	public enum EventChangeType {
+		/// <summary>
+		/// Item added
+		/// </summary>
+		Add,
+
+		/// <summary>
+		/// Item removed
+		/// </summary>
+		Remove
+	}
+
+	/// <summary>
+	/// Stores data on a map field change
+	/// </summary>
+	public struct EventMapChange<TKey, TValue> {
+		/// <summary>
+		/// The key that changed
+		/// </summary>
+		public readonly TKey Key;
+
+		/// <summary>
+		/// The value that changed
+		/// </summary>
+		public readonly TValue Value;
+
+		/// <summary>
+		/// The type of change
+		/// </summary>
+		public readonly EventChangeType ChangeType;
+
+		/// <summary>
+		/// Default constructor
+		/// </summary>
+		public EventMapChange(TKey key, TValue value, EventChangeType changeType) {
+			Key = key;
+			Value = value;
+			ChangeType = changeType;
+		}
+	}
+
+	/// <summary>
+	/// Stores data on a repeated field change
+	/// </summary>
+	public struct EventListChange<T> {
+		/// <summary>
+		/// The index that changed
+		/// </summary>
+		public readonly int Index;
+
+		/// <summary>
+		/// The item that changed
+		/// </summary>
+		public readonly T Value;
+
+		/// <summary>
+		/// The type of change
+		/// </summary>
+		public readonly EventChangeType ChangeType;
+
+		/// <summary>
+		/// Default constructor
+		/// </summary>
+		public EventListChange(int index, T value, EventChangeType changeType) {
+			Index = index;
+			Value = value;
+			ChangeType = changeType;
+		}
+	}
+}

--- a/runtime/src/Zynga.Protobuf.Runtime/EventMapConverter.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventMapConverter.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using Google.Protobuf;
-using Zynga.Protobuf.Runtime.EventSource;
 
 namespace Zynga.Protobuf.Runtime {
 	public abstract class EventMapConverter<TKey, TValue> {
@@ -8,7 +7,7 @@ namespace Zynga.Protobuf.Runtime {
 		/// Returns EventContent for the specified data
 		/// </summary>
 		public abstract ByteString GetKeyValue(TKey key, TValue value, bool skipValue = false);
-		
+
 		/// <summary>
 		/// Returns the data for the specified EventContent
 		/// </summary>

--- a/runtime/src/Zynga.Protobuf.Runtime/EventRepeatedField.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventRepeatedField.cs
@@ -9,12 +9,13 @@ namespace Zynga.Protobuf.Runtime {
 	/// <summary>
 	/// Wraps a repeated field to add event sourcing support
 	/// </summary>
-	public class EventRepeatedField<T> : IEventSubscribable, IList<T>, ICollection<T>, IEnumerable<T>, IEnumerable, IList, ICollection, IDeepCloneable<RepeatedField<T>>, IEquatable<RepeatedField<T>>, IReadOnlyList<T>, IReadOnlyCollection<T> {
+	public class EventRepeatedField<T> : IEventSubscribable, IList<T>, IList, IDeepCloneable<RepeatedField<T>>, IEquatable<RepeatedField<T>>, IReadOnlyList<T> {
 		private readonly RepeatedField<T> _internal;
 		private readonly bool _isMessageType;
 		private EventContext _context;
 		private int _fieldNumber;
 		private readonly EventDataConverter<T> _converter;
+		private readonly List<EventListChange<T>> _itemsChanged = new List<EventListChange<T>>();
 
 		public EventRepeatedField(EventDataConverter<T> converter, bool isMessageType = false) {
 			_converter = converter;
@@ -40,17 +41,33 @@ namespace Zynga.Protobuf.Runtime {
 		/// <summary>
 		/// Subcribe to changes of this message
 		/// </summary>
-		public event Action<EventRepeatedField<T>> OnChanged;
+		public event Action<EventRepeatedField<T>, IReadOnlyList<EventListChange<T>>> OnChanged;
 
 		/// <inheritdoc />
 		public void NotifySubscribers() {
-			OnChanged?.Invoke(this);
+			try {
+				OnChanged?.Invoke(this, _itemsChanged);
+			}
+			finally {
+				_itemsChanged.Clear();
+			}
 		}
 
-		/// <summary>
-		/// Mark the message dirty
-		/// </summary>
-		protected void MarkDirty() {
+		private void MarkDirtyAdd(int index, T item) {
+			if (OnChanged != null && OnChanged.GetInvocationList().Length > 0) {
+				_context.MarkDirty(this);
+				_itemsChanged.Add(new EventListChange<T>(index, item, EventChangeType.Add));
+			}
+		}
+
+		private void MarkDirtyRemove(int index, T item) {
+			if (OnChanged != null && OnChanged.GetInvocationList().Length > 0) {
+				_context.MarkDirty(this);
+				_itemsChanged.Add(new EventListChange<T>(index, item, EventChangeType.Remove));
+			}
+		}
+
+		private void MarkDirty() {
 			if (OnChanged != null && OnChanged.GetInvocationList().Length > 0) {
 				_context.MarkDirty(this);
 			}
@@ -80,34 +97,34 @@ namespace Zynga.Protobuf.Runtime {
 
 		public void Add(T item) {
 			InternalAdd(item);
-			#if !DISABLE_EVENTS
+#if !DISABLE_EVENTS
 			AddListEvent(item);
-			#endif
+#endif
 		}
 
 		public void Add(EventRepeatedField<T> other) {
 			foreach (var v in other) {
 				InternalAdd(v);
-				#if !DISABLE_EVENTS
+#if !DISABLE_EVENTS
 				AddListEvent(v);
-				#endif
+#endif
 			}
 		}
 
 		public void Add(IList<T> other) {
 			foreach (var v in other) {
 				InternalAdd(v);
-				#if !DISABLE_EVENTS
+#if !DISABLE_EVENTS
 				AddListEvent(v);
-				#endif
+#endif
 			}
 		}
 
 		public void Clear() {
 			InternalClear();
-			#if !DISABLE_EVENTS
+#if !DISABLE_EVENTS
 			ClearListEvent();
-			#endif
+#endif
 		}
 
 		public bool Contains(T item) {
@@ -120,11 +137,11 @@ namespace Zynga.Protobuf.Runtime {
 
 		public bool Remove(T item) {
 			var result = InternalRemove(item);
-			#if !DISABLE_EVENTS
+#if !DISABLE_EVENTS
 			if (result) {
 				RemoveListEvent(item);
 			}
-			#endif
+#endif
 
 			return result;
 		}
@@ -173,16 +190,16 @@ namespace Zynga.Protobuf.Runtime {
 
 		public void Insert(int index, T item) {
 			InternalInsert(index, item);
-			#if !DISABLE_EVENTS
+#if !DISABLE_EVENTS
 			InsertListEvent(index, item);
-			#endif
+#endif
 		}
 
 		public void RemoveAt(int index) {
 			InternalRemoveAt(index);
-			#if !DISABLE_EVENTS
+#if !DISABLE_EVENTS
 			RemoveAtListEvent(index);
-			#endif
+#endif
 		}
 
 		public override string ToString() {
@@ -192,15 +209,15 @@ namespace Zynga.Protobuf.Runtime {
 		public T this[int index] {
 			get { return _internal[index]; }
 			set {
-				#if !DISABLE_EVENTS
+#if !DISABLE_EVENTS
 				var generateEvent = !value.Equals(_internal[index]);
-				#endif
+#endif
 				InternalReplaceAt(index, value);
-				#if !DISABLE_EVENTS
+#if !DISABLE_EVENTS
 				if (generateEvent) {
 					ReplaceListEvent(index, value);
 				}
-				#endif
+#endif
 			}
 		}
 
@@ -313,7 +330,6 @@ namespace Zynga.Protobuf.Runtime {
 		}
 
 		public bool ApplyEvent(ListEvent e) {
-			MarkDirty();
 			switch (e.ListAction) {
 				case ListAction.AddList:
 					InternalAdd(_converter.GetItem(e.Content));
@@ -332,10 +348,12 @@ namespace Zynga.Protobuf.Runtime {
 					return true;
 				case ListAction.ClearList:
 					InternalClear();
+					MarkDirty();
 					return true;
 				case ListAction.UpdateList:
 					var registry = _internal[e.Index] as IEventRegistry;
 					registry?.ApplyEvent(e.EventData, 0);
+					MarkDirty();
 					return true;
 				default:
 					return false;
@@ -355,6 +373,7 @@ namespace Zynga.Protobuf.Runtime {
 		private void InternalRemoveAt(int index) {
 			var removedItem = _internal[index];
 			_internal.RemoveAt(index);
+			MarkDirtyRemove(index, removedItem);
 			if (_isMessageType) {
 				ClearParent(removedItem);
 				UpdateParents(index);
@@ -363,12 +382,15 @@ namespace Zynga.Protobuf.Runtime {
 
 		private void InternalAdd(T item) {
 			_internal.Add(item);
+			MarkDirtyAdd(_internal.Count - 1, item);
 			if (_isMessageType) SetParent(_internal.Count - 1, item);
 		}
 
 		private void InternalReplaceAt(int index, T item) {
 			var removedItem = _internal[index];
 			_internal[index] = item;
+			MarkDirtyRemove(index, removedItem);
+			MarkDirtyAdd(index, item);
 			if (_isMessageType) {
 				ClearParent(removedItem);
 				SetParent(index, item);
@@ -377,6 +399,7 @@ namespace Zynga.Protobuf.Runtime {
 
 		private void InternalInsert(int index, T item) {
 			_internal.Insert(index, item);
+			MarkDirtyAdd(index, item);
 			if (_isMessageType) {
 				SetParent(index, item);
 				UpdateParents(index + 1);
@@ -386,7 +409,11 @@ namespace Zynga.Protobuf.Runtime {
 		private void InternalClear() {
 			if (_isMessageType) {
 				while (_internal.Count > 0) {
-					InternalRemoveAt(0);
+					var removedItem = _internal[0];
+					_internal.RemoveAt(0);
+					if (_isMessageType) {
+						ClearParent(removedItem);
+					}
 				}
 			}
 			else {

--- a/runtime/src/Zynga.Protobuf.Runtime/EventUtils.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventUtils.cs
@@ -10,7 +10,7 @@ namespace Zynga.Protobuf.Runtime
 {
     public static class EventUtils
     {
-        public static void GetChecksum(this global::Google.Protobuf.WellKnownTypes.Timestamp tmp, BinaryWriter inWriter)
+        public static void GetChecksum(this Google.Protobuf.WellKnownTypes.Timestamp tmp, BinaryWriter inWriter)
         {
             using (var memStream = new MemoryStream())
             {
@@ -22,7 +22,7 @@ namespace Zynga.Protobuf.Runtime
             }
         }
 
-        public static void GetChecksum(this global::Google.Protobuf.WellKnownTypes.Duration tmp, BinaryWriter inWriter)
+        public static void GetChecksum(this Google.Protobuf.WellKnownTypes.Duration tmp, BinaryWriter inWriter)
         {
             using (var memStream = new MemoryStream())
             {

--- a/runtime/src/Zynga.Protobuf.Runtime/IEventRegistry.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/IEventRegistry.cs
@@ -1,0 +1,71 @@
+﻿using Zynga.Protobuf.Runtime.EventSource;
+
+namespace Zynga.Protobuf.Runtime {
+	/// <summary>
+	/// EventRegistry is extended by protobuf messages with the event_sourced option set. This interface is useful
+	/// for methods that do not require the message Type.
+	/// </summary>
+	public interface IEventRegistry {
+		/// <summary>
+		/// Takes a set of events and applies them to the Message
+		/// </summary>
+		/// <param name="root"></param>
+		void ApplyEvents(EventSourceRoot root);
+
+		/// <summary>
+		/// Applies a specific event with the current path index specified.
+		/// This is for internal use only.
+		/// </summary>
+		/// <param name="e"></param>
+		/// <param name="pathIndex"></param>
+		/// <returns>true if the event was applied</returns>
+		bool ApplyEvent(EventData e, int pathIndex);
+
+		/// <summary>
+		/// Generates a snapshot of the state
+		/// </summary>
+		EventSourceRoot GenerateSnapshot();
+
+		/// <summary>
+		/// Returns the existing set of events, this does not clear the events associated with the messages
+		/// </summary>
+		/// <returns></returns>
+		EventSourceRoot PeekEvents();
+
+		/// <summary>
+		/// Returns true if the object currently has Events
+		/// </summary>
+		bool HasEvents { get; }
+
+		/// <summary>
+		/// Returns the existing set of events and clears them
+		/// </summary>
+		/// <returns></returns>
+		EventSourceRoot GenerateEvents();
+
+		/// <summary>
+		/// Clears the existing events that have been generated
+		/// </summary>
+		void ClearEvents();
+
+		/// <summary>
+		/// Used to establish a parent child relationship between a message and child message.
+		/// This is for internal use only.
+		/// </summary>
+		/// <param name="parent"></param>
+		/// <param name="path"></param>
+		void SetParent(EventContext parent, EventPath path);
+
+		/// <summary>
+		/// Clears the existing parent, this is typically called when a child message is replaced or a message
+		/// is removed from a list or a map. This is for internal use only.
+		/// </summary>
+		void ClearParent();
+
+		/// <summary>
+		/// Used for ListEventContext objects, which may have had their index updated by a replace or insert event
+		/// </summary>
+		/// <param name="index"></param>
+		void TryUpdateContextIndex(int index);
+	}
+}

--- a/runtime/src/Zynga.Protobuf.Runtime/IEventSubscribable.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/IEventSubscribable.cs
@@ -1,0 +1,8 @@
+﻿namespace Zynga.Protobuf.Runtime {
+	public interface IEventSubscribable {
+		/// <summary>
+		/// Notify any event listeners
+		/// </summary>
+		void NotifySubscribers();
+	}
+}

--- a/runtime/src/Zynga.Protobuf.Runtime/ListEventContext.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/ListEventContext.cs
@@ -69,5 +69,10 @@ namespace Zynga.Protobuf.Runtime {
 
 			AddUpdateEvent(e);
 		}
+
+		/// <inheritdoc />
+		public override void MarkDirty(IEventSubscribable eventRegistry) {
+			_listContext.MarkDirty(eventRegistry);
+		}
 	}
 }

--- a/runtime/src/Zynga.Protobuf.Runtime/MapEventContext.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/MapEventContext.cs
@@ -62,5 +62,10 @@ namespace Zynga.Protobuf.Runtime {
 
 			AddUpdateEvent(e);
 		}
+
+		/// <inheritdoc />
+		public override void MarkDirty(IEventSubscribable eventRegistry) {
+			_mapContext.MarkDirty(eventRegistry);
+		}
 	}
 }


### PR DESCRIPTION
A tpyical pattern seen with event sourcing is a target will receive a stream of events and maintain its own replica of the state.  A challenge that arises is how to update a view of that data without having to re-examine the entire data structure.  These changes will allow for event listeners to be notified when changes are made to a specific Message, List or Map.