### PR TITLE
Fixing an issue with applying a snapshot

### DIFF
--- a/plugin/src/lib/csharp_enum_field.cc
+++ b/plugin/src/lib/csharp_enum_field.cc
@@ -93,7 +93,12 @@ EnumOneofFieldGenerator::~EnumOneofFieldGenerator() {
 }
 
 void EnumOneofFieldGenerator::GenerateMergingCode(io::Printer* printer, bool isEventSourced) {
-  printer->Print(variables_, "$property_name$ = other.$property_name$;\n");
+  if(isEventSourced) {
+    printer->Print(variables_, "$name$_ = other.$property_name$;\n");
+  }
+  else {
+    printer->Print(variables_, "$property_name$ = other.$property_name$;\n");
+  }
 }
 
 void EnumOneofFieldGenerator::GenerateParsingCode(io::Printer* printer, bool isEventSourced) {

--- a/plugin/src/lib/csharp_message_field.cc
+++ b/plugin/src/lib/csharp_message_field.cc
@@ -400,6 +400,7 @@ void MessageOneofFieldGenerator::GenerateMergingCode(io::Printer* printer, bool 
 
 void MessageOneofFieldGenerator::GenerateParsingCode(io::Printer* printer, bool isEventSourced) {
   // TODO(jonskeet): We may be able to do better than this
+  bool isInternalEventSourced = IsInternalEventSourced();
   printer->Print(
     variables_,
     "$type_name$ subBuilder = new $type_name$();\n"
@@ -407,7 +408,13 @@ void MessageOneofFieldGenerator::GenerateParsingCode(io::Printer* printer, bool 
     "  subBuilder.MergeFrom($property_name$);\n"
     "}\n"
     "input.ReadMessage(subBuilder);\n" // No support of TYPE_GROUP
-    "$property_name$ = subBuilder;\n");
+
+    "$oneof_name$_ = subBuilder;\n"
+    "$oneof_name$Case_ = $oneof_property_name$OneofCase.$property_name$;\n");
+  if(isEventSourced && isInternalEventSourced) {
+    printer->Print(variables_,
+      "subBuilder.SetParent(Context, new EventPath(Context.Path, $number$));\n");
+  }
 }
 
 void MessageOneofFieldGenerator::WriteToString(io::Printer* printer) {

--- a/plugin/src/lib/csharp_primitive_field.cc
+++ b/plugin/src/lib/csharp_primitive_field.cc
@@ -209,7 +209,7 @@ void PrimitiveFieldGenerator::GenerateMergingCode(io::Printer* printer, bool isE
   printer->Print(
     variables_,
     "if ($other_has_property_check$) {\n"
-    "  $property_name$ = other.$property_name$;\n"
+    "  $name$_ = other.$property_name$;\n"
     "}\n");
 }
 
@@ -218,7 +218,7 @@ void PrimitiveFieldGenerator::GenerateParsingCode(io::Printer* printer, bool isE
   // so that we can normalize "null to empty" for strings and bytes.
   printer->Print(
     variables_,
-    "$property_name$ = input.Read$capitalized_type_name$();\n");
+    "$name$_ = input.Read$capitalized_type_name$();\n");
 }
 
 void PrimitiveFieldGenerator::GenerateSerializationCode(io::Printer* printer) {
@@ -410,7 +410,8 @@ void PrimitiveOneofFieldGenerator::WriteToString(io::Printer* printer) {
 void PrimitiveOneofFieldGenerator::GenerateParsingCode(io::Printer* printer, bool isEventSourced) {
     printer->Print(
       variables_,
-      "$property_name$ = input.Read$capitalized_type_name$();\n");
+      "$oneof_name$_ = input.Read$capitalized_type_name$();\n"
+      "$oneof_name$Case_ = $oneof_property_name$OneofCase.$property_name$;\n");
 }
 
 void PrimitiveOneofFieldGenerator::GenerateCloningCode(io::Printer* printer, bool isEventSourced) {

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/ComplexTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/ComplexTest.cs
@@ -379,22 +379,22 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         return;
       }
       if (other.J != 0) {
-        J = other.J;
+        j_ = other.J;
       }
       if (other.K != 0) {
-        K = other.K;
+        k_ = other.K;
       }
       if (other.L != 0) {
-        L = other.L;
+        l_ = other.L;
       }
       if (other.M != 0) {
-        M = other.M;
+        m_ = other.M;
       }
       if (other.N != 0) {
-        N = other.N;
+        n_ = other.N;
       }
       if (other.O != 0) {
-        O = other.O;
+        o_ = other.O;
       }
       switch (other.ACase) {
         case AOneofCase.B:
@@ -422,31 +422,33 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               subBuilder.MergeFrom(B);
             }
             input.ReadMessage(subBuilder);
-            B = subBuilder;
+            a_ = subBuilder;
+            aCase_ = AOneofCase.B;
+            subBuilder.SetParent(Context, new EventPath(Context.Path, 1));
             break;
           }
           case 16: {
-            J = input.ReadInt32();
+            j_ = input.ReadInt32();
             break;
           }
           case 24: {
-            K = input.ReadInt32();
+            k_ = input.ReadInt32();
             break;
           }
           case 32: {
-            L = input.ReadInt32();
+            l_ = input.ReadInt32();
             break;
           }
           case 40: {
-            M = input.ReadInt32();
+            m_ = input.ReadInt32();
             break;
           }
           case 48: {
-            N = input.ReadInt32();
+            n_ = input.ReadInt32();
             break;
           }
           case 56: {
-            O = input.ReadInt32();
+            o_ = input.ReadInt32();
             break;
           }
         }
@@ -802,22 +804,22 @@ namespace Com.Zynga.Runtime.Protobuf.File {
       }
       c_.Add(other.c_);
       if (other.I != 0) {
-        I = other.I;
+        i_ = other.I;
       }
       if (other.K != 0) {
-        K = other.K;
+        k_ = other.K;
       }
       if (other.L != 0) {
-        L = other.L;
+        l_ = other.L;
       }
       if (other.M != 0) {
-        M = other.M;
+        m_ = other.M;
       }
       if (other.N != 0) {
-        N = other.N;
+        n_ = other.N;
       }
       if (other.O != 0) {
-        O = other.O;
+        o_ = other.O;
       }
     }
 
@@ -830,7 +832,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             input.SkipLastField();
             break;
           case 8: {
-            I = input.ReadInt32();
+            i_ = input.ReadInt32();
             break;
           }
           case 18: {
@@ -838,23 +840,23 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             break;
           }
           case 24: {
-            K = input.ReadInt32();
+            k_ = input.ReadInt32();
             break;
           }
           case 32: {
-            L = input.ReadInt32();
+            l_ = input.ReadInt32();
             break;
           }
           case 40: {
-            M = input.ReadInt32();
+            m_ = input.ReadInt32();
             break;
           }
           case 48: {
-            N = input.ReadInt32();
+            n_ = input.ReadInt32();
             break;
           }
           case 56: {
-            O = input.ReadInt32();
+            o_ = input.ReadInt32();
             break;
           }
         }
@@ -1200,22 +1202,22 @@ namespace Com.Zynga.Runtime.Protobuf.File {
       }
       d_.Add(other.d_);
       if (other.I != 0) {
-        I = other.I;
+        i_ = other.I;
       }
       if (other.J != 0) {
-        J = other.J;
+        j_ = other.J;
       }
       if (other.L != 0) {
-        L = other.L;
+        l_ = other.L;
       }
       if (other.M != 0) {
-        M = other.M;
+        m_ = other.M;
       }
       if (other.N != 0) {
-        N = other.N;
+        n_ = other.N;
       }
       if (other.O != 0) {
-        O = other.O;
+        o_ = other.O;
       }
     }
 
@@ -1228,11 +1230,11 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             input.SkipLastField();
             break;
           case 8: {
-            I = input.ReadInt32();
+            i_ = input.ReadInt32();
             break;
           }
           case 16: {
-            J = input.ReadInt32();
+            j_ = input.ReadInt32();
             break;
           }
           case 26: {
@@ -1240,19 +1242,19 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             break;
           }
           case 32: {
-            L = input.ReadInt32();
+            l_ = input.ReadInt32();
             break;
           }
           case 40: {
-            M = input.ReadInt32();
+            m_ = input.ReadInt32();
             break;
           }
           case 48: {
-            N = input.ReadInt32();
+            n_ = input.ReadInt32();
             break;
           }
           case 56: {
-            O = input.ReadInt32();
+            o_ = input.ReadInt32();
             break;
           }
         }
@@ -1590,22 +1592,22 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         E.MergeFrom(other.E);
       }
       if (other.I != 0) {
-        I = other.I;
+        i_ = other.I;
       }
       if (other.J != 0) {
-        J = other.J;
+        j_ = other.J;
       }
       if (other.K != 0) {
-        K = other.K;
+        k_ = other.K;
       }
       if (other.M != 0) {
-        M = other.M;
+        m_ = other.M;
       }
       if (other.N != 0) {
-        N = other.N;
+        n_ = other.N;
       }
       if (other.O != 0) {
-        O = other.O;
+        o_ = other.O;
       }
     }
 
@@ -1618,15 +1620,15 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             input.SkipLastField();
             break;
           case 8: {
-            I = input.ReadInt32();
+            i_ = input.ReadInt32();
             break;
           }
           case 16: {
-            J = input.ReadInt32();
+            j_ = input.ReadInt32();
             break;
           }
           case 24: {
-            K = input.ReadInt32();
+            k_ = input.ReadInt32();
             break;
           }
           case 34: {
@@ -1638,15 +1640,15 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             break;
           }
           case 40: {
-            M = input.ReadInt32();
+            m_ = input.ReadInt32();
             break;
           }
           case 48: {
-            N = input.ReadInt32();
+            n_ = input.ReadInt32();
             break;
           }
           case 56: {
-            O = input.ReadInt32();
+            o_ = input.ReadInt32();
             break;
           }
         }
@@ -1993,22 +1995,22 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         F.MergeFrom(other.F);
       }
       if (other.I != 0) {
-        I = other.I;
+        i_ = other.I;
       }
       if (other.J != 0) {
-        J = other.J;
+        j_ = other.J;
       }
       if (other.K != 0) {
-        K = other.K;
+        k_ = other.K;
       }
       if (other.L != 0) {
-        L = other.L;
+        l_ = other.L;
       }
       if (other.N != 0) {
-        N = other.N;
+        n_ = other.N;
       }
       if (other.O != 0) {
-        O = other.O;
+        o_ = other.O;
       }
     }
 
@@ -2021,19 +2023,19 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             input.SkipLastField();
             break;
           case 8: {
-            I = input.ReadInt32();
+            i_ = input.ReadInt32();
             break;
           }
           case 16: {
-            J = input.ReadInt32();
+            j_ = input.ReadInt32();
             break;
           }
           case 24: {
-            K = input.ReadInt32();
+            k_ = input.ReadInt32();
             break;
           }
           case 32: {
-            L = input.ReadInt32();
+            l_ = input.ReadInt32();
             break;
           }
           case 42: {
@@ -2045,11 +2047,11 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             break;
           }
           case 48: {
-            N = input.ReadInt32();
+            n_ = input.ReadInt32();
             break;
           }
           case 56: {
-            O = input.ReadInt32();
+            o_ = input.ReadInt32();
             break;
           }
         }
@@ -2396,22 +2398,22 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         G.MergeFrom(other.G);
       }
       if (other.I != 0) {
-        I = other.I;
+        i_ = other.I;
       }
       if (other.J != 0) {
-        J = other.J;
+        j_ = other.J;
       }
       if (other.K != 0) {
-        K = other.K;
+        k_ = other.K;
       }
       if (other.L != 0) {
-        L = other.L;
+        l_ = other.L;
       }
       if (other.M != 0) {
-        M = other.M;
+        m_ = other.M;
       }
       if (other.O != 0) {
-        O = other.O;
+        o_ = other.O;
       }
     }
 
@@ -2424,23 +2426,23 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             input.SkipLastField();
             break;
           case 8: {
-            I = input.ReadInt32();
+            i_ = input.ReadInt32();
             break;
           }
           case 16: {
-            J = input.ReadInt32();
+            j_ = input.ReadInt32();
             break;
           }
           case 24: {
-            K = input.ReadInt32();
+            k_ = input.ReadInt32();
             break;
           }
           case 32: {
-            L = input.ReadInt32();
+            l_ = input.ReadInt32();
             break;
           }
           case 40: {
-            M = input.ReadInt32();
+            m_ = input.ReadInt32();
             break;
           }
           case 50: {
@@ -2452,7 +2454,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             break;
           }
           case 56: {
-            O = input.ReadInt32();
+            o_ = input.ReadInt32();
             break;
           }
         }
@@ -2792,22 +2794,22 @@ namespace Com.Zynga.Runtime.Protobuf.File {
       }
       h_.Add(other.h_);
       if (other.I != 0) {
-        I = other.I;
+        i_ = other.I;
       }
       if (other.J != 0) {
-        J = other.J;
+        j_ = other.J;
       }
       if (other.K != 0) {
-        K = other.K;
+        k_ = other.K;
       }
       if (other.L != 0) {
-        L = other.L;
+        l_ = other.L;
       }
       if (other.M != 0) {
-        M = other.M;
+        m_ = other.M;
       }
       if (other.N != 0) {
-        N = other.N;
+        n_ = other.N;
       }
     }
 
@@ -2820,27 +2822,27 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             input.SkipLastField();
             break;
           case 8: {
-            I = input.ReadInt32();
+            i_ = input.ReadInt32();
             break;
           }
           case 16: {
-            J = input.ReadInt32();
+            j_ = input.ReadInt32();
             break;
           }
           case 24: {
-            K = input.ReadInt32();
+            k_ = input.ReadInt32();
             break;
           }
           case 32: {
-            L = input.ReadInt32();
+            l_ = input.ReadInt32();
             break;
           }
           case 40: {
-            M = input.ReadInt32();
+            m_ = input.ReadInt32();
             break;
           }
           case 48: {
-            N = input.ReadInt32();
+            n_ = input.ReadInt32();
             break;
           }
           case 58:
@@ -3105,13 +3107,13 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         P.MergeFrom(other.P);
       }
       if (other.T != 0) {
-        T = other.T;
+        t_ = other.T;
       }
       if (other.U != 0) {
-        U = other.U;
+        u_ = other.U;
       }
       if (other.V != 0) {
-        V = other.V;
+        v_ = other.V;
       }
     }
 
@@ -3132,15 +3134,15 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             break;
           }
           case 72: {
-            T = input.ReadInt32();
+            t_ = input.ReadInt32();
             break;
           }
           case 80: {
-            U = input.ReadInt32();
+            u_ = input.ReadInt32();
             break;
           }
           case 88: {
-            V = input.ReadInt32();
+            v_ = input.ReadInt32();
             break;
           }
         }
@@ -3397,13 +3399,13 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         Q.MergeFrom(other.Q);
       }
       if (other.S != 0) {
-        S = other.S;
+        s_ = other.S;
       }
       if (other.U != 0) {
-        U = other.U;
+        u_ = other.U;
       }
       if (other.V != 0) {
-        V = other.V;
+        v_ = other.V;
       }
     }
 
@@ -3416,7 +3418,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             input.SkipLastField();
             break;
           case 64: {
-            S = input.ReadInt32();
+            s_ = input.ReadInt32();
             break;
           }
           case 74: {
@@ -3428,11 +3430,11 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             break;
           }
           case 80: {
-            U = input.ReadInt32();
+            u_ = input.ReadInt32();
             break;
           }
           case 88: {
-            V = input.ReadInt32();
+            v_ = input.ReadInt32();
             break;
           }
         }
@@ -3683,13 +3685,13 @@ namespace Com.Zynga.Runtime.Protobuf.File {
       }
       r_.Add(other.r_);
       if (other.S != 0) {
-        S = other.S;
+        s_ = other.S;
       }
       if (other.T != 0) {
-        T = other.T;
+        t_ = other.T;
       }
       if (other.V != 0) {
-        V = other.V;
+        v_ = other.V;
       }
     }
 
@@ -3702,11 +3704,11 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             input.SkipLastField();
             break;
           case 64: {
-            S = input.ReadInt32();
+            s_ = input.ReadInt32();
             break;
           }
           case 72: {
-            T = input.ReadInt32();
+            t_ = input.ReadInt32();
             break;
           }
           case 82: {
@@ -3714,7 +3716,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             break;
           }
           case 88: {
-            V = input.ReadInt32();
+            v_ = input.ReadInt32();
             break;
           }
         }
@@ -3953,16 +3955,16 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         return;
       }
       if (other.R.Length != 0) {
-        R = other.R;
+        r_ = other.R;
       }
       if (other.S != 0) {
-        S = other.S;
+        s_ = other.S;
       }
       if (other.T != 0) {
-        T = other.T;
+        t_ = other.T;
       }
       if (other.U != 0) {
-        U = other.U;
+        u_ = other.U;
       }
     }
 
@@ -3975,19 +3977,19 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             input.SkipLastField();
             break;
           case 64: {
-            S = input.ReadInt32();
+            s_ = input.ReadInt32();
             break;
           }
           case 72: {
-            T = input.ReadInt32();
+            t_ = input.ReadInt32();
             break;
           }
           case 80: {
-            U = input.ReadInt32();
+            u_ = input.ReadInt32();
             break;
           }
           case 90: {
-            R = input.ReadString();
+            r_ = input.ReadString();
             break;
           }
         }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
@@ -704,7 +704,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         Zam.MergeFrom(other.Zam);
       }
       if (other.FieldBool != false) {
-        FieldBool = other.FieldBool;
+        fieldBool_ = other.FieldBool;
       }
       if (other.timestamp_ != null) {
         if (timestamp_ == null) {
@@ -801,15 +801,19 @@ namespace Com.Zynga.Runtime.Protobuf {
               subBuilder.MergeFrom(Maybefoo);
             }
             input.ReadMessage(subBuilder);
-            Maybefoo = subBuilder;
+            test_ = subBuilder;
+            testCase_ = TestOneofCase.Maybefoo;
+            subBuilder.SetParent(Context, new EventPath(Context.Path, 8));
             break;
           }
           case 72: {
-            Maybeint = input.ReadInt32();
+            test_ = input.ReadInt32();
+            testCase_ = TestOneofCase.Maybeint;
             break;
           }
           case 82: {
-            Maybestring = input.ReadString();
+            test_ = input.ReadString();
+            testCase_ = TestOneofCase.Maybestring;
             break;
           }
           case 90: {
@@ -820,7 +824,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             break;
           }
           case 96: {
-            FieldBool = input.ReadBool();
+            fieldBool_ = input.ReadBool();
             break;
           }
           case 106: {
@@ -1210,10 +1214,10 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.Long != 0L) {
-        Long = other.Long;
+        long_ = other.Long;
       }
       if (other.Str.Length != 0) {
-        Str = other.Str;
+        str_ = other.Str;
       }
       if (other.foo_ != null) {
         if (foo_ == null) {
@@ -1223,10 +1227,10 @@ namespace Com.Zynga.Runtime.Protobuf {
         Foo_.MergeFrom(other.Foo_);
       }
       if (other.Enumero != 0) {
-        Enumero = other.Enumero;
+        enumero_ = other.Enumero;
       }
       if (other.Okay != 0) {
-        Okay = other.Okay;
+        okay_ = other.Okay;
       }
     }
 
@@ -1239,11 +1243,11 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 8: {
-            Long = input.ReadInt64();
+            long_ = input.ReadInt64();
             break;
           }
           case 18: {
-            Str = input.ReadString();
+            str_ = input.ReadString();
             break;
           }
           case 26: {
@@ -1381,7 +1385,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             return;
           }
           if (other.Hi != 0) {
-            Hi = other.Hi;
+            hi_ = other.Hi;
           }
         }
 
@@ -1394,7 +1398,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 input.SkipLastField();
                 break;
               case 8: {
-                Hi = input.ReadInt32();
+                hi_ = input.ReadInt32();
                 break;
               }
             }
@@ -2142,49 +2146,49 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.A != 0) {
-        A = other.A;
+        a_ = other.A;
       }
       if (other.B != 0) {
-        B = other.B;
+        b_ = other.B;
       }
       if (other.C != 0UL) {
-        C = other.C;
+        c_ = other.C;
       }
       if (other.D != 0) {
-        D = other.D;
+        d_ = other.D;
       }
       if (other.E != 0L) {
-        E = other.E;
+        e_ = other.E;
       }
       if (other.F != 0) {
-        F = other.F;
+        f_ = other.F;
       }
       if (other.G != 0D) {
-        G = other.G;
+        g_ = other.G;
       }
       if (other.H != 0F) {
-        H = other.H;
+        h_ = other.H;
       }
       if (other.I != false) {
-        I = other.I;
+        i_ = other.I;
       }
       if (other.J.Length != 0) {
-        J = other.J;
+        j_ = other.J;
       }
       if (other.K.Length != 0) {
-        K = other.K;
+        k_ = other.K;
       }
       if (other.L != 0L) {
-        L = other.L;
+        l_ = other.L;
       }
       if (other.M != 0UL) {
-        M = other.M;
+        m_ = other.M;
       }
       if (other.N != 0) {
-        N = other.N;
+        n_ = other.N;
       }
       if (other.O != 0L) {
-        O = other.O;
+        o_ = other.O;
       }
     }
 
@@ -2197,63 +2201,63 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 8: {
-            A = input.ReadUInt32();
+            a_ = input.ReadUInt32();
             break;
           }
           case 16: {
-            B = input.ReadInt32();
+            b_ = input.ReadInt32();
             break;
           }
           case 25: {
-            C = input.ReadFixed64();
+            c_ = input.ReadFixed64();
             break;
           }
           case 37: {
-            D = input.ReadFixed32();
+            d_ = input.ReadFixed32();
             break;
           }
           case 41: {
-            E = input.ReadSFixed64();
+            e_ = input.ReadSFixed64();
             break;
           }
           case 53: {
-            F = input.ReadSFixed32();
+            f_ = input.ReadSFixed32();
             break;
           }
           case 57: {
-            G = input.ReadDouble();
+            g_ = input.ReadDouble();
             break;
           }
           case 69: {
-            H = input.ReadFloat();
+            h_ = input.ReadFloat();
             break;
           }
           case 72: {
-            I = input.ReadBool();
+            i_ = input.ReadBool();
             break;
           }
           case 82: {
-            J = input.ReadString();
+            j_ = input.ReadString();
             break;
           }
           case 90: {
-            K = input.ReadBytes();
+            k_ = input.ReadBytes();
             break;
           }
           case 96: {
-            L = input.ReadInt64();
+            l_ = input.ReadInt64();
             break;
           }
           case 104: {
-            M = input.ReadUInt64();
+            m_ = input.ReadUInt64();
             break;
           }
           case 112: {
-            N = input.ReadSInt32();
+            n_ = input.ReadSInt32();
             break;
           }
           case 120: {
-            O = input.ReadSInt64();
+            o_ = input.ReadSInt64();
             break;
           }
         }
@@ -2561,7 +2565,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         Primitives.MergeFrom(other.Primitives);
       }
       if (other.Enumero != 0) {
-        Enumero = other.Enumero;
+        enumero_ = other.Enumero;
       }
       if (other.bar_ != null) {
         if (bar_ == null) {
@@ -2869,7 +2873,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         Primitives.MergeFrom(other.Primitives);
       }
       if (other.Enumero != 0) {
-        Enumero = other.Enumero;
+        enumero_ = other.Enumero;
       }
       if (other.bar_ != null) {
         if (bar_ == null) {

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
@@ -186,7 +186,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.Data != 0) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -199,7 +199,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 8: {
-            Data = input.ReadInt32();
+            data_ = input.ReadInt32();
             break;
           }
         }
@@ -322,7 +322,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.Data != 0) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -335,7 +335,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 8: {
-            Data = input.ReadInt32();
+            data_ = input.ReadInt32();
             break;
           }
         }
@@ -916,10 +916,10 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.EventId.Length != 0) {
-        EventId = other.EventId;
+        eventId_ = other.EventId;
       }
       if (other.TestEvent != 0) {
-        TestEvent = other.TestEvent;
+        testEvent_ = other.TestEvent;
       }
       testPrim_.Add(other.testPrim_);
       testMessage_.Add(other.testMessage_);
@@ -940,10 +940,10 @@ namespace Com.Zynga.Runtime.Protobuf {
         TestNonMessage.MergeFrom(other.TestNonMessage);
       }
       if (other.TestStringNoChecksum.Length != 0) {
-        TestStringNoChecksum = other.TestStringNoChecksum;
+        testStringNoChecksum_ = other.TestStringNoChecksum;
       }
       if (other.TestBytesField.Length != 0) {
-        TestBytesField = other.TestBytesField;
+        testBytesField_ = other.TestBytesField;
       }
       if (other.date_ != null) {
         if (date_ == null) {
@@ -975,11 +975,12 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 10: {
-            EventId = input.ReadString();
+            eventId_ = input.ReadString();
             break;
           }
           case 18: {
-            Foo = input.ReadString();
+            testOneof_ = input.ReadString();
+            testOneofCase_ = TestOneofOneofCase.Foo;
             break;
           }
           case 26: {
@@ -988,7 +989,9 @@ namespace Com.Zynga.Runtime.Protobuf {
               subBuilder.MergeFrom(Internal);
             }
             input.ReadMessage(subBuilder);
-            Internal = subBuilder;
+            testOneof_ = subBuilder;
+            testOneofCase_ = TestOneofOneofCase.Internal;
+            subBuilder.SetParent(Context, new EventPath(Context.Path, 3));
             break;
           }
           case 32: {
@@ -1033,11 +1036,11 @@ namespace Com.Zynga.Runtime.Protobuf {
             break;
           }
           case 98: {
-            TestStringNoChecksum = input.ReadString();
+            testStringNoChecksum_ = input.ReadString();
             break;
           }
           case 106: {
-            TestBytesField = input.ReadBytes();
+            testBytesField_ = input.ReadBytes();
             break;
           }
           case 114: {
@@ -1198,7 +1201,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             return;
           }
           if (other.Data != 0) {
-            Data = other.Data;
+            data_ = other.Data;
           }
           if (other.dataTwo_ != null) {
             if (dataTwo_ == null) {
@@ -1218,7 +1221,7 @@ namespace Com.Zynga.Runtime.Protobuf {
                 input.SkipLastField();
                 break;
               case 8: {
-                Data = input.ReadInt32();
+                data_ = input.ReadInt32();
                 break;
               }
               case 18: {
@@ -1465,7 +1468,8 @@ namespace Com.Zynga.Runtime.Protobuf {
                 input.SkipLastField();
                 break;
               case 10: {
-                Foo = input.ReadString();
+                body_ = input.ReadString();
+                bodyCase_ = BodyOneofCase.Foo;
                 break;
               }
               case 18: {
@@ -1474,7 +1478,8 @@ namespace Com.Zynga.Runtime.Protobuf {
                   subBuilder.MergeFrom(Internal);
                 }
                 input.ReadMessage(subBuilder);
-                Internal = subBuilder;
+                body_ = subBuilder;
+                bodyCase_ = BodyOneofCase.Internal;
                 break;
               }
             }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/FileTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/FileTest.cs
@@ -800,7 +800,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         Zam.MergeFrom(other.Zam);
       }
       if (other.FieldBool != false) {
-        FieldBool = other.FieldBool;
+        fieldBool_ = other.FieldBool;
       }
       if (other.timestamp_ != null) {
         if (timestamp_ == null) {
@@ -916,15 +916,19 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               subBuilder.MergeFrom(Maybefoo);
             }
             input.ReadMessage(subBuilder);
-            Maybefoo = subBuilder;
+            test_ = subBuilder;
+            testCase_ = TestOneofCase.Maybefoo;
+            subBuilder.SetParent(Context, new EventPath(Context.Path, 8));
             break;
           }
           case 72: {
-            Maybeint = input.ReadInt32();
+            test_ = input.ReadInt32();
+            testCase_ = TestOneofCase.Maybeint;
             break;
           }
           case 82: {
-            Maybestring = input.ReadString();
+            test_ = input.ReadString();
+            testCase_ = TestOneofCase.Maybestring;
             break;
           }
           case 90: {
@@ -936,7 +940,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             break;
           }
           case 96: {
-            FieldBool = input.ReadBool();
+            fieldBool_ = input.ReadBool();
             break;
           }
           case 106: {
@@ -975,7 +979,8 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               subBuilder.MergeFrom(NoEventsA);
             }
             input.ReadMessage(subBuilder);
-            NoEventsA = subBuilder;
+            test_ = subBuilder;
+            testCase_ = TestOneofCase.NoEventsA;
             break;
           }
           case 146: {
@@ -991,7 +996,9 @@ namespace Com.Zynga.Runtime.Protobuf.File {
               subBuilder.MergeFrom(HasEventsA);
             }
             input.ReadMessage(subBuilder);
-            HasEventsA = subBuilder;
+            test_ = subBuilder;
+            testCase_ = TestOneofCase.HasEventsA;
+            subBuilder.SetParent(Context, new EventPath(Context.Path, 19));
             break;
           }
         }
@@ -1383,10 +1390,10 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         return;
       }
       if (other.Long != 0L) {
-        Long = other.Long;
+        long_ = other.Long;
       }
       if (other.Str.Length != 0) {
-        Str = other.Str;
+        str_ = other.Str;
       }
       if (other.foo_ != null) {
         if (foo_ == null) {
@@ -1396,10 +1403,10 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         Foo_.MergeFrom(other.Foo_);
       }
       if (other.Enumero != 0) {
-        Enumero = other.Enumero;
+        enumero_ = other.Enumero;
       }
       if (other.Okay != 0) {
-        Okay = other.Okay;
+        okay_ = other.Okay;
       }
     }
 
@@ -1412,11 +1419,11 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             input.SkipLastField();
             break;
           case 8: {
-            Long = input.ReadInt64();
+            long_ = input.ReadInt64();
             break;
           }
           case 18: {
-            Str = input.ReadString();
+            str_ = input.ReadString();
             break;
           }
           case 26: {
@@ -1554,7 +1561,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             return;
           }
           if (other.Hi != 0) {
-            Hi = other.Hi;
+            hi_ = other.Hi;
           }
         }
 
@@ -1567,7 +1574,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
                 input.SkipLastField();
                 break;
               case 8: {
-                Hi = input.ReadInt32();
+                hi_ = input.ReadInt32();
                 break;
               }
             }
@@ -2315,49 +2322,49 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         return;
       }
       if (other.A != 0) {
-        A = other.A;
+        a_ = other.A;
       }
       if (other.B != 0) {
-        B = other.B;
+        b_ = other.B;
       }
       if (other.C != 0UL) {
-        C = other.C;
+        c_ = other.C;
       }
       if (other.D != 0) {
-        D = other.D;
+        d_ = other.D;
       }
       if (other.E != 0L) {
-        E = other.E;
+        e_ = other.E;
       }
       if (other.F != 0) {
-        F = other.F;
+        f_ = other.F;
       }
       if (other.G != 0D) {
-        G = other.G;
+        g_ = other.G;
       }
       if (other.H != 0F) {
-        H = other.H;
+        h_ = other.H;
       }
       if (other.I != false) {
-        I = other.I;
+        i_ = other.I;
       }
       if (other.J.Length != 0) {
-        J = other.J;
+        j_ = other.J;
       }
       if (other.K.Length != 0) {
-        K = other.K;
+        k_ = other.K;
       }
       if (other.L != 0L) {
-        L = other.L;
+        l_ = other.L;
       }
       if (other.M != 0UL) {
-        M = other.M;
+        m_ = other.M;
       }
       if (other.N != 0) {
-        N = other.N;
+        n_ = other.N;
       }
       if (other.O != 0L) {
-        O = other.O;
+        o_ = other.O;
       }
     }
 
@@ -2370,63 +2377,63 @@ namespace Com.Zynga.Runtime.Protobuf.File {
             input.SkipLastField();
             break;
           case 8: {
-            A = input.ReadUInt32();
+            a_ = input.ReadUInt32();
             break;
           }
           case 16: {
-            B = input.ReadInt32();
+            b_ = input.ReadInt32();
             break;
           }
           case 25: {
-            C = input.ReadFixed64();
+            c_ = input.ReadFixed64();
             break;
           }
           case 37: {
-            D = input.ReadFixed32();
+            d_ = input.ReadFixed32();
             break;
           }
           case 41: {
-            E = input.ReadSFixed64();
+            e_ = input.ReadSFixed64();
             break;
           }
           case 53: {
-            F = input.ReadSFixed32();
+            f_ = input.ReadSFixed32();
             break;
           }
           case 57: {
-            G = input.ReadDouble();
+            g_ = input.ReadDouble();
             break;
           }
           case 69: {
-            H = input.ReadFloat();
+            h_ = input.ReadFloat();
             break;
           }
           case 72: {
-            I = input.ReadBool();
+            i_ = input.ReadBool();
             break;
           }
           case 82: {
-            J = input.ReadString();
+            j_ = input.ReadString();
             break;
           }
           case 90: {
-            K = input.ReadBytes();
+            k_ = input.ReadBytes();
             break;
           }
           case 96: {
-            L = input.ReadInt64();
+            l_ = input.ReadInt64();
             break;
           }
           case 104: {
-            M = input.ReadUInt64();
+            m_ = input.ReadUInt64();
             break;
           }
           case 112: {
-            N = input.ReadSInt32();
+            n_ = input.ReadSInt32();
             break;
           }
           case 120: {
-            O = input.ReadSInt64();
+            o_ = input.ReadSInt64();
             break;
           }
         }
@@ -2734,7 +2741,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         Primitives.MergeFrom(other.Primitives);
       }
       if (other.Enumero != 0) {
-        Enumero = other.Enumero;
+        enumero_ = other.Enumero;
       }
       if (other.bar_ != null) {
         if (bar_ == null) {
@@ -3042,7 +3049,7 @@ namespace Com.Zynga.Runtime.Protobuf.File {
         Primitives.MergeFrom(other.Primitives);
       }
       if (other.Enumero != 0) {
-        Enumero = other.Enumero;
+        enumero_ = other.Enumero;
       }
       if (other.bar_ != null) {
         if (bar_ == null) {

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/NoEventsTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/NoEventsTest.cs
@@ -144,7 +144,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.A != 0) {
-        A = other.A;
+        a_ = other.A;
       }
     }
 
@@ -157,7 +157,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 8: {
-            A = input.ReadInt32();
+            a_ = input.ReadInt32();
             break;
           }
         }
@@ -273,7 +273,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.A != 0) {
-        A = other.A;
+        a_ = other.A;
       }
     }
 
@@ -286,7 +286,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 8: {
-            A = input.ReadInt32();
+            a_ = input.ReadInt32();
             break;
           }
         }
@@ -505,7 +505,8 @@ namespace Com.Zynga.Runtime.Protobuf {
               subBuilder.MergeFrom(HasB);
             }
             input.ReadMessage(subBuilder);
-            HasB = subBuilder;
+            foo_ = subBuilder;
+            fooCase_ = FooOneofCase.HasB;
             break;
           }
         }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/AllTypesTestsHelper.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/AllTypesTestsHelper.cs
@@ -748,11 +748,13 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 			allTypes.OneofBytes = ByteValue(offsetIndex);
 			allTypes.OneofForeignMessage = ForeignMessageValue(offsetIndex);
 			allTypes.OneofForeignMessageNoEvents = ForeignMessageNoEventsValue(offsetIndex);
-			allTypes.OneofAllTypes = TestAllTypesValue(offsetIndex);
 			allTypes.OneofAllTypesNoEvents = TestAllTypesNoEventsValue(offsetIndex);
+			allTypes.OneofAllTypes = TestAllTypesValue(offsetIndex);
+			SetNestedMessages(allTypes.OneofAllTypes, offsetIndex);
 
 			// nested types
 			allTypes.AllTypes = TestAllTypesValue(offsetIndex);
+			SetNestedMessages(allTypes.AllTypes , offsetIndex);
 			allTypes.AllTypesNoEvents = TestAllTypesNoEventsValue(offsetIndex);
 		}
 

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleList.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleList.cs
@@ -176,7 +176,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.G.Length != 0) {
-        G = other.G;
+        g_ = other.G;
       }
     }
 
@@ -189,7 +189,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 10: {
-            G = input.ReadString();
+            g_ = input.ReadString();
             break;
           }
         }
@@ -305,7 +305,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.H.Length != 0) {
-        H = other.H;
+        h_ = other.H;
       }
     }
 
@@ -318,7 +318,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 10: {
-            H = input.ReadString();
+            h_ = input.ReadString();
             break;
           }
         }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMap.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMap.cs
@@ -200,7 +200,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.G.Length != 0) {
-        G = other.G;
+        g_ = other.G;
       }
     }
 
@@ -213,7 +213,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 10: {
-            G = input.ReadString();
+            g_ = input.ReadString();
             break;
           }
         }
@@ -329,7 +329,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.H.Length != 0) {
-        H = other.H;
+        h_ = other.H;
       }
     }
 
@@ -342,7 +342,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 10: {
-            H = input.ReadString();
+            h_ = input.ReadString();
             break;
           }
         }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMessage.cs
@@ -182,7 +182,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.A != 0) {
-        A = other.A;
+        a_ = other.A;
       }
       if (other.b_ != null) {
         if (b_ == null) {
@@ -202,7 +202,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 8: {
-            A = input.ReadInt32();
+            a_ = input.ReadInt32();
             break;
           }
           case 18: {
@@ -397,7 +397,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.C != 0L) {
-        C = other.C;
+        c_ = other.C;
       }
       if (other.d_ != null) {
         if (d_ == null) {
@@ -417,7 +417,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 24: {
-            C = input.ReadInt64();
+            c_ = input.ReadInt64();
             break;
           }
           case 34: {
@@ -584,7 +584,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.E != 0L) {
-        E = other.E;
+        e_ = other.E;
       }
     }
 
@@ -597,7 +597,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 40: {
-            E = input.ReadInt64();
+            e_ = input.ReadInt64();
             break;
           }
         }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/UnittestImportProto3.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/UnittestImportProto3.cs
@@ -164,7 +164,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.D != 0) {
-        D = other.D;
+        d_ = other.D;
       }
     }
 
@@ -177,7 +177,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            D = input.ReadInt32();
+            d_ = input.ReadInt32();
             break;
           }
         }
@@ -313,7 +313,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.D != 0) {
-        D = other.D;
+        d_ = other.D;
       }
     }
 
@@ -326,7 +326,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            D = input.ReadInt32();
+            d_ = input.ReadInt32();
             break;
           }
         }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/UnittestImportPublicProto3.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/UnittestImportPublicProto3.cs
@@ -151,7 +151,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.E != 0) {
-        E = other.E;
+        e_ = other.E;
       }
     }
 
@@ -164,7 +164,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            E = input.ReadInt32();
+            e_ = input.ReadInt32();
             break;
           }
         }
@@ -300,7 +300,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.E != 0) {
-        E = other.E;
+        e_ = other.E;
       }
     }
 
@@ -313,7 +313,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            E = input.ReadInt32();
+            e_ = input.ReadInt32();
             break;
           }
         }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/UnittestProto3.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/UnittestProto3.cs
@@ -3210,49 +3210,49 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.SingleInt32 != 0) {
-        SingleInt32 = other.SingleInt32;
+        singleInt32_ = other.SingleInt32;
       }
       if (other.SingleInt64 != 0L) {
-        SingleInt64 = other.SingleInt64;
+        singleInt64_ = other.SingleInt64;
       }
       if (other.SingleUint32 != 0) {
-        SingleUint32 = other.SingleUint32;
+        singleUint32_ = other.SingleUint32;
       }
       if (other.SingleUint64 != 0UL) {
-        SingleUint64 = other.SingleUint64;
+        singleUint64_ = other.SingleUint64;
       }
       if (other.SingleSint32 != 0) {
-        SingleSint32 = other.SingleSint32;
+        singleSint32_ = other.SingleSint32;
       }
       if (other.SingleSint64 != 0L) {
-        SingleSint64 = other.SingleSint64;
+        singleSint64_ = other.SingleSint64;
       }
       if (other.SingleFixed32 != 0) {
-        SingleFixed32 = other.SingleFixed32;
+        singleFixed32_ = other.SingleFixed32;
       }
       if (other.SingleFixed64 != 0UL) {
-        SingleFixed64 = other.SingleFixed64;
+        singleFixed64_ = other.SingleFixed64;
       }
       if (other.SingleSfixed32 != 0) {
-        SingleSfixed32 = other.SingleSfixed32;
+        singleSfixed32_ = other.SingleSfixed32;
       }
       if (other.SingleSfixed64 != 0L) {
-        SingleSfixed64 = other.SingleSfixed64;
+        singleSfixed64_ = other.SingleSfixed64;
       }
       if (other.SingleFloat != 0F) {
-        SingleFloat = other.SingleFloat;
+        singleFloat_ = other.SingleFloat;
       }
       if (other.SingleDouble != 0D) {
-        SingleDouble = other.SingleDouble;
+        singleDouble_ = other.SingleDouble;
       }
       if (other.SingleBool != false) {
-        SingleBool = other.SingleBool;
+        singleBool_ = other.SingleBool;
       }
       if (other.SingleString.Length != 0) {
-        SingleString = other.SingleString;
+        singleString_ = other.SingleString;
       }
       if (other.SingleBytes.Length != 0) {
-        SingleBytes = other.SingleBytes;
+        singleBytes_ = other.SingleBytes;
       }
       if (other.singleNestedMessage_ != null) {
         if (singleNestedMessage_ == null) {
@@ -3276,13 +3276,13 @@ namespace Google.Protobuf.TestProtos {
         SingleImportMessage.MergeFrom(other.SingleImportMessage);
       }
       if (other.SingleNestedEnum != 0) {
-        SingleNestedEnum = other.SingleNestedEnum;
+        singleNestedEnum_ = other.SingleNestedEnum;
       }
       if (other.SingleForeignEnum != 0) {
-        SingleForeignEnum = other.SingleForeignEnum;
+        singleForeignEnum_ = other.SingleForeignEnum;
       }
       if (other.SingleImportEnum != 0) {
-        SingleImportEnum = other.SingleImportEnum;
+        singleImportEnum_ = other.SingleImportEnum;
       }
       if (other.singlePublicImportMessage_ != null) {
         if (singlePublicImportMessage_ == null) {
@@ -3404,63 +3404,63 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            SingleInt32 = input.ReadInt32();
+            singleInt32_ = input.ReadInt32();
             break;
           }
           case 16: {
-            SingleInt64 = input.ReadInt64();
+            singleInt64_ = input.ReadInt64();
             break;
           }
           case 24: {
-            SingleUint32 = input.ReadUInt32();
+            singleUint32_ = input.ReadUInt32();
             break;
           }
           case 32: {
-            SingleUint64 = input.ReadUInt64();
+            singleUint64_ = input.ReadUInt64();
             break;
           }
           case 40: {
-            SingleSint32 = input.ReadSInt32();
+            singleSint32_ = input.ReadSInt32();
             break;
           }
           case 48: {
-            SingleSint64 = input.ReadSInt64();
+            singleSint64_ = input.ReadSInt64();
             break;
           }
           case 61: {
-            SingleFixed32 = input.ReadFixed32();
+            singleFixed32_ = input.ReadFixed32();
             break;
           }
           case 65: {
-            SingleFixed64 = input.ReadFixed64();
+            singleFixed64_ = input.ReadFixed64();
             break;
           }
           case 77: {
-            SingleSfixed32 = input.ReadSFixed32();
+            singleSfixed32_ = input.ReadSFixed32();
             break;
           }
           case 81: {
-            SingleSfixed64 = input.ReadSFixed64();
+            singleSfixed64_ = input.ReadSFixed64();
             break;
           }
           case 93: {
-            SingleFloat = input.ReadFloat();
+            singleFloat_ = input.ReadFloat();
             break;
           }
           case 97: {
-            SingleDouble = input.ReadDouble();
+            singleDouble_ = input.ReadDouble();
             break;
           }
           case 104: {
-            SingleBool = input.ReadBool();
+            singleBool_ = input.ReadBool();
             break;
           }
           case 114: {
-            SingleString = input.ReadString();
+            singleString_ = input.ReadString();
             break;
           }
           case 122: {
-            SingleBytes = input.ReadBytes();
+            singleBytes_ = input.ReadBytes();
             break;
           }
           case 146: {
@@ -3620,7 +3620,8 @@ namespace Google.Protobuf.TestProtos {
             break;
           }
           case 888: {
-            OneofUint32 = input.ReadUInt32();
+            oneofField_ = input.ReadUInt32();
+            oneofFieldCase_ = OneofFieldOneofCase.OneofUint32;
             break;
           }
           case 898: {
@@ -3629,15 +3630,19 @@ namespace Google.Protobuf.TestProtos {
               subBuilder.MergeFrom(OneofNestedMessage);
             }
             input.ReadMessage(subBuilder);
-            OneofNestedMessage = subBuilder;
+            oneofField_ = subBuilder;
+            oneofFieldCase_ = OneofFieldOneofCase.OneofNestedMessage;
+            subBuilder.SetParent(Context, new EventPath(Context.Path, 112));
             break;
           }
           case 906: {
-            OneofString = input.ReadString();
+            oneofField_ = input.ReadString();
+            oneofFieldCase_ = OneofFieldOneofCase.OneofString;
             break;
           }
           case 914: {
-            OneofBytes = input.ReadBytes();
+            oneofField_ = input.ReadBytes();
+            oneofFieldCase_ = OneofFieldOneofCase.OneofBytes;
             break;
           }
           case 922: {
@@ -3741,7 +3746,9 @@ namespace Google.Protobuf.TestProtos {
               subBuilder.MergeFrom(OneofForeignMessage);
             }
             input.ReadMessage(subBuilder);
-            OneofForeignMessage = subBuilder;
+            oneofField_ = subBuilder;
+            oneofFieldCase_ = OneofFieldOneofCase.OneofForeignMessage;
+            subBuilder.SetParent(Context, new EventPath(Context.Path, 137));
             break;
           }
           case 1106: {
@@ -3750,7 +3757,8 @@ namespace Google.Protobuf.TestProtos {
               subBuilder.MergeFrom(OneofForeignMessageNoEvents);
             }
             input.ReadMessage(subBuilder);
-            OneofForeignMessageNoEvents = subBuilder;
+            oneofField_ = subBuilder;
+            oneofFieldCase_ = OneofFieldOneofCase.OneofForeignMessageNoEvents;
             break;
           }
           case 1114: {
@@ -3759,7 +3767,9 @@ namespace Google.Protobuf.TestProtos {
               subBuilder.MergeFrom(OneofAllTypes);
             }
             input.ReadMessage(subBuilder);
-            OneofAllTypes = subBuilder;
+            oneofField_ = subBuilder;
+            oneofFieldCase_ = OneofFieldOneofCase.OneofAllTypes;
+            subBuilder.SetParent(Context, new EventPath(Context.Path, 139));
             break;
           }
           case 1122: {
@@ -3768,7 +3778,8 @@ namespace Google.Protobuf.TestProtos {
               subBuilder.MergeFrom(OneofAllTypesNoEvents);
             }
             input.ReadMessage(subBuilder);
-            OneofAllTypesNoEvents = subBuilder;
+            oneofField_ = subBuilder;
+            oneofFieldCase_ = OneofFieldOneofCase.OneofAllTypesNoEvents;
             break;
           }
         }
@@ -3902,7 +3913,7 @@ namespace Google.Protobuf.TestProtos {
             return;
           }
           if (other.Bb != 0) {
-            Bb = other.Bb;
+            bb_ = other.Bb;
           }
         }
 
@@ -3915,7 +3926,7 @@ namespace Google.Protobuf.TestProtos {
                 input.SkipLastField();
                 break;
               case 8: {
-                Bb = input.ReadInt32();
+                bb_ = input.ReadInt32();
                 break;
               }
             }
@@ -4751,7 +4762,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.DeprecatedInt32 != 0) {
-        DeprecatedInt32 = other.DeprecatedInt32;
+        deprecatedInt32_ = other.DeprecatedInt32;
       }
     }
 
@@ -4764,7 +4775,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            DeprecatedInt32 = input.ReadInt32();
+            deprecatedInt32_ = input.ReadInt32();
             break;
           }
         }
@@ -4914,7 +4925,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.C != 0) {
-        C = other.C;
+        c_ = other.C;
       }
     }
 
@@ -4927,7 +4938,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            C = input.ReadInt32();
+            c_ = input.ReadInt32();
             break;
           }
         }
@@ -5409,10 +5420,10 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.A != 0) {
-        A = other.A;
+        a_ = other.A;
       }
       if (other.Bb != 0) {
-        Bb = other.Bb;
+        bb_ = other.Bb;
       }
     }
 
@@ -5425,11 +5436,11 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            A = input.ReadInt32();
+            a_ = input.ReadInt32();
             break;
           }
           case 2147483640: {
-            Bb = input.ReadInt32();
+            bb_ = input.ReadInt32();
             break;
           }
         }
@@ -5614,7 +5625,7 @@ namespace Google.Protobuf.TestProtos {
         A.MergeFrom(other.A);
       }
       if (other.I != 0) {
-        I = other.I;
+        i_ = other.I;
       }
     }
 
@@ -5635,7 +5646,7 @@ namespace Google.Protobuf.TestProtos {
             break;
           }
           case 16: {
-            I = input.ReadInt32();
+            i_ = input.ReadInt32();
             break;
           }
         }
@@ -6010,7 +6021,7 @@ namespace Google.Protobuf.TestProtos {
         A.MergeFrom(other.A);
       }
       if (other.OptionalInt32 != 0) {
-        OptionalInt32 = other.OptionalInt32;
+        optionalInt32_ = other.OptionalInt32;
       }
     }
 
@@ -6031,7 +6042,7 @@ namespace Google.Protobuf.TestProtos {
             break;
           }
           case 16: {
-            OptionalInt32 = input.ReadInt32();
+            optionalInt32_ = input.ReadInt32();
             break;
           }
         }
@@ -6190,7 +6201,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Value != 0) {
-        Value = other.Value;
+        value_ = other.Value;
       }
     }
 
@@ -6542,13 +6553,13 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.PrimitiveField != 0) {
-        PrimitiveField = other.PrimitiveField;
+        primitiveField_ = other.PrimitiveField;
       }
       if (other.StringField.Length != 0) {
-        StringField = other.StringField;
+        stringField_ = other.StringField;
       }
       if (other.EnumField != 0) {
-        EnumField = other.EnumField;
+        enumField_ = other.EnumField;
       }
       if (other.messageField_ != null) {
         if (messageField_ == null) {
@@ -6572,11 +6583,11 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            PrimitiveField = input.ReadInt32();
+            primitiveField_ = input.ReadInt32();
             break;
           }
           case 18: {
-            StringField = input.ReadString();
+            stringField_ = input.ReadString();
             break;
           }
           case 24: {
@@ -6873,13 +6884,13 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.MyString.Length != 0) {
-        MyString = other.MyString;
+        myString_ = other.MyString;
       }
       if (other.MyInt != 0L) {
-        MyInt = other.MyInt;
+        myInt_ = other.MyInt;
       }
       if (other.MyFloat != 0F) {
-        MyFloat = other.MyFloat;
+        myFloat_ = other.MyFloat;
       }
       if (other.singleNestedMessage_ != null) {
         if (singleNestedMessage_ == null) {
@@ -6899,15 +6910,15 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            MyInt = input.ReadInt64();
+            myInt_ = input.ReadInt64();
             break;
           }
           case 90: {
-            MyString = input.ReadString();
+            myString_ = input.ReadString();
             break;
           }
           case 813: {
-            MyFloat = input.ReadFloat();
+            myFloat_ = input.ReadFloat();
             break;
           }
           case 1602: {
@@ -7064,10 +7075,10 @@ namespace Google.Protobuf.TestProtos {
             return;
           }
           if (other.Oo != 0L) {
-            Oo = other.Oo;
+            oo_ = other.Oo;
           }
           if (other.Bb != 0) {
-            Bb = other.Bb;
+            bb_ = other.Bb;
           }
         }
 
@@ -7080,11 +7091,11 @@ namespace Google.Protobuf.TestProtos {
                 input.SkipLastField();
                 break;
               case 8: {
-                Bb = input.ReadInt32();
+                bb_ = input.ReadInt32();
                 break;
               }
               case 16: {
-                Oo = input.ReadInt64();
+                oo_ = input.ReadInt64();
                 break;
               }
             }
@@ -7290,7 +7301,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.SparseEnum != 0) {
-        SparseEnum = other.SparseEnum;
+        sparseEnum_ = other.SparseEnum;
       }
     }
 
@@ -7452,7 +7463,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data.Length != 0) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -7465,7 +7476,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 10: {
-            Data = input.ReadString();
+            data_ = input.ReadString();
             break;
           }
         }
@@ -7769,7 +7780,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data.Length != 0) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -7782,7 +7793,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 10: {
-            Data = input.ReadBytes();
+            data_ = input.ReadBytes();
             break;
           }
         }
@@ -7928,7 +7939,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data.Length != 0) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -7941,7 +7952,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 10: {
-            Data = input.ReadBytes();
+            data_ = input.ReadBytes();
             break;
           }
         }
@@ -8090,7 +8101,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data != 0) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -8103,7 +8114,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            Data = input.ReadInt32();
+            data_ = input.ReadInt32();
             break;
           }
         }
@@ -8249,7 +8260,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data != 0) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -8262,7 +8273,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            Data = input.ReadUInt32();
+            data_ = input.ReadUInt32();
             break;
           }
         }
@@ -8408,7 +8419,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data != 0L) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -8421,7 +8432,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            Data = input.ReadInt64();
+            data_ = input.ReadInt64();
             break;
           }
         }
@@ -8567,7 +8578,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data != 0UL) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -8580,7 +8591,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            Data = input.ReadUInt64();
+            data_ = input.ReadUInt64();
             break;
           }
         }
@@ -8726,7 +8737,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data != false) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -8739,7 +8750,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            Data = input.ReadBool();
+            data_ = input.ReadBool();
             break;
           }
         }
@@ -8998,11 +9009,13 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            FooInt = input.ReadInt32();
+            foo_ = input.ReadInt32();
+            fooCase_ = FooOneofCase.FooInt;
             break;
           }
           case 18: {
-            FooString = input.ReadString();
+            foo_ = input.ReadString();
+            fooCase_ = FooOneofCase.FooString;
             break;
           }
           case 26: {
@@ -9011,7 +9024,9 @@ namespace Google.Protobuf.TestProtos {
               subBuilder.MergeFrom(FooMessage);
             }
             input.ReadMessage(subBuilder);
-            FooMessage = subBuilder;
+            foo_ = subBuilder;
+            fooCase_ = FooOneofCase.FooMessage;
+            subBuilder.SetParent(Context, new EventPath(Context.Path, 3));
             break;
           }
         }
@@ -10822,7 +10837,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.A.Length != 0) {
-        A = other.A;
+        a_ = other.A;
       }
     }
 
@@ -10835,7 +10850,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 10: {
-            A = input.ReadString();
+            a_ = input.ReadString();
             break;
           }
         }
@@ -13216,49 +13231,49 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.SingleInt32 != 0) {
-        SingleInt32 = other.SingleInt32;
+        singleInt32_ = other.SingleInt32;
       }
       if (other.SingleInt64 != 0L) {
-        SingleInt64 = other.SingleInt64;
+        singleInt64_ = other.SingleInt64;
       }
       if (other.SingleUint32 != 0) {
-        SingleUint32 = other.SingleUint32;
+        singleUint32_ = other.SingleUint32;
       }
       if (other.SingleUint64 != 0UL) {
-        SingleUint64 = other.SingleUint64;
+        singleUint64_ = other.SingleUint64;
       }
       if (other.SingleSint32 != 0) {
-        SingleSint32 = other.SingleSint32;
+        singleSint32_ = other.SingleSint32;
       }
       if (other.SingleSint64 != 0L) {
-        SingleSint64 = other.SingleSint64;
+        singleSint64_ = other.SingleSint64;
       }
       if (other.SingleFixed32 != 0) {
-        SingleFixed32 = other.SingleFixed32;
+        singleFixed32_ = other.SingleFixed32;
       }
       if (other.SingleFixed64 != 0UL) {
-        SingleFixed64 = other.SingleFixed64;
+        singleFixed64_ = other.SingleFixed64;
       }
       if (other.SingleSfixed32 != 0) {
-        SingleSfixed32 = other.SingleSfixed32;
+        singleSfixed32_ = other.SingleSfixed32;
       }
       if (other.SingleSfixed64 != 0L) {
-        SingleSfixed64 = other.SingleSfixed64;
+        singleSfixed64_ = other.SingleSfixed64;
       }
       if (other.SingleFloat != 0F) {
-        SingleFloat = other.SingleFloat;
+        singleFloat_ = other.SingleFloat;
       }
       if (other.SingleDouble != 0D) {
-        SingleDouble = other.SingleDouble;
+        singleDouble_ = other.SingleDouble;
       }
       if (other.SingleBool != false) {
-        SingleBool = other.SingleBool;
+        singleBool_ = other.SingleBool;
       }
       if (other.SingleString.Length != 0) {
-        SingleString = other.SingleString;
+        singleString_ = other.SingleString;
       }
       if (other.SingleBytes.Length != 0) {
-        SingleBytes = other.SingleBytes;
+        singleBytes_ = other.SingleBytes;
       }
       if (other.singleNestedMessage_ != null) {
         if (singleNestedMessage_ == null) {
@@ -13279,13 +13294,13 @@ namespace Google.Protobuf.TestProtos {
         SingleImportMessage.MergeFrom(other.SingleImportMessage);
       }
       if (other.SingleNestedEnum != 0) {
-        SingleNestedEnum = other.SingleNestedEnum;
+        singleNestedEnum_ = other.SingleNestedEnum;
       }
       if (other.SingleForeignEnum != 0) {
-        SingleForeignEnum = other.SingleForeignEnum;
+        singleForeignEnum_ = other.SingleForeignEnum;
       }
       if (other.SingleImportEnum != 0) {
-        SingleImportEnum = other.SingleImportEnum;
+        singleImportEnum_ = other.SingleImportEnum;
       }
       if (other.singlePublicImportMessage_ != null) {
         if (singlePublicImportMessage_ == null) {
@@ -13403,63 +13418,63 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            SingleInt32 = input.ReadInt32();
+            singleInt32_ = input.ReadInt32();
             break;
           }
           case 16: {
-            SingleInt64 = input.ReadInt64();
+            singleInt64_ = input.ReadInt64();
             break;
           }
           case 24: {
-            SingleUint32 = input.ReadUInt32();
+            singleUint32_ = input.ReadUInt32();
             break;
           }
           case 32: {
-            SingleUint64 = input.ReadUInt64();
+            singleUint64_ = input.ReadUInt64();
             break;
           }
           case 40: {
-            SingleSint32 = input.ReadSInt32();
+            singleSint32_ = input.ReadSInt32();
             break;
           }
           case 48: {
-            SingleSint64 = input.ReadSInt64();
+            singleSint64_ = input.ReadSInt64();
             break;
           }
           case 61: {
-            SingleFixed32 = input.ReadFixed32();
+            singleFixed32_ = input.ReadFixed32();
             break;
           }
           case 65: {
-            SingleFixed64 = input.ReadFixed64();
+            singleFixed64_ = input.ReadFixed64();
             break;
           }
           case 77: {
-            SingleSfixed32 = input.ReadSFixed32();
+            singleSfixed32_ = input.ReadSFixed32();
             break;
           }
           case 81: {
-            SingleSfixed64 = input.ReadSFixed64();
+            singleSfixed64_ = input.ReadSFixed64();
             break;
           }
           case 93: {
-            SingleFloat = input.ReadFloat();
+            singleFloat_ = input.ReadFloat();
             break;
           }
           case 97: {
-            SingleDouble = input.ReadDouble();
+            singleDouble_ = input.ReadDouble();
             break;
           }
           case 104: {
-            SingleBool = input.ReadBool();
+            singleBool_ = input.ReadBool();
             break;
           }
           case 114: {
-            SingleString = input.ReadString();
+            singleString_ = input.ReadString();
             break;
           }
           case 122: {
-            SingleBytes = input.ReadBytes();
+            singleBytes_ = input.ReadBytes();
             break;
           }
           case 146: {
@@ -13619,7 +13634,8 @@ namespace Google.Protobuf.TestProtos {
             break;
           }
           case 888: {
-            OneofUint32 = input.ReadUInt32();
+            oneofField_ = input.ReadUInt32();
+            oneofFieldCase_ = OneofFieldOneofCase.OneofUint32;
             break;
           }
           case 898: {
@@ -13628,15 +13644,18 @@ namespace Google.Protobuf.TestProtos {
               subBuilder.MergeFrom(OneofNestedMessage);
             }
             input.ReadMessage(subBuilder);
-            OneofNestedMessage = subBuilder;
+            oneofField_ = subBuilder;
+            oneofFieldCase_ = OneofFieldOneofCase.OneofNestedMessage;
             break;
           }
           case 906: {
-            OneofString = input.ReadString();
+            oneofField_ = input.ReadString();
+            oneofFieldCase_ = OneofFieldOneofCase.OneofString;
             break;
           }
           case 914: {
-            OneofBytes = input.ReadBytes();
+            oneofField_ = input.ReadBytes();
+            oneofFieldCase_ = OneofFieldOneofCase.OneofBytes;
             break;
           }
           case 922: {
@@ -13739,7 +13758,8 @@ namespace Google.Protobuf.TestProtos {
               subBuilder.MergeFrom(OneofForeignMessage);
             }
             input.ReadMessage(subBuilder);
-            OneofForeignMessage = subBuilder;
+            oneofField_ = subBuilder;
+            oneofFieldCase_ = OneofFieldOneofCase.OneofForeignMessage;
             break;
           }
           case 1106: {
@@ -13748,7 +13768,8 @@ namespace Google.Protobuf.TestProtos {
               subBuilder.MergeFrom(OneofForeignMessageNoEvents);
             }
             input.ReadMessage(subBuilder);
-            OneofForeignMessageNoEvents = subBuilder;
+            oneofField_ = subBuilder;
+            oneofFieldCase_ = OneofFieldOneofCase.OneofForeignMessageNoEvents;
             break;
           }
           case 1114: {
@@ -13757,7 +13778,8 @@ namespace Google.Protobuf.TestProtos {
               subBuilder.MergeFrom(OneofAllTypes);
             }
             input.ReadMessage(subBuilder);
-            OneofAllTypes = subBuilder;
+            oneofField_ = subBuilder;
+            oneofFieldCase_ = OneofFieldOneofCase.OneofAllTypes;
             break;
           }
           case 1122: {
@@ -13766,7 +13788,8 @@ namespace Google.Protobuf.TestProtos {
               subBuilder.MergeFrom(OneofAllTypesNoEvents);
             }
             input.ReadMessage(subBuilder);
-            OneofAllTypesNoEvents = subBuilder;
+            oneofField_ = subBuilder;
+            oneofFieldCase_ = OneofFieldOneofCase.OneofAllTypesNoEvents;
             break;
           }
         }
@@ -13890,7 +13913,7 @@ namespace Google.Protobuf.TestProtos {
             return;
           }
           if (other.Bb != 0) {
-            Bb = other.Bb;
+            bb_ = other.Bb;
           }
         }
 
@@ -13903,7 +13926,7 @@ namespace Google.Protobuf.TestProtos {
                 input.SkipLastField();
                 break;
               case 8: {
-                Bb = input.ReadInt32();
+                bb_ = input.ReadInt32();
                 break;
               }
             }
@@ -14197,7 +14220,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.DeprecatedInt32 != 0) {
-        DeprecatedInt32 = other.DeprecatedInt32;
+        deprecatedInt32_ = other.DeprecatedInt32;
       }
     }
 
@@ -14210,7 +14233,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            DeprecatedInt32 = input.ReadInt32();
+            deprecatedInt32_ = input.ReadInt32();
             break;
           }
         }
@@ -14320,7 +14343,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.C != 0) {
-        C = other.C;
+        c_ = other.C;
       }
     }
 
@@ -14333,7 +14356,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            C = input.ReadInt32();
+            c_ = input.ReadInt32();
             break;
           }
         }
@@ -14686,10 +14709,10 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.A != 0) {
-        A = other.A;
+        a_ = other.A;
       }
       if (other.Bb != 0) {
-        Bb = other.Bb;
+        bb_ = other.Bb;
       }
     }
 
@@ -14702,11 +14725,11 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            A = input.ReadInt32();
+            a_ = input.ReadInt32();
             break;
           }
           case 2147483640: {
-            Bb = input.ReadInt32();
+            bb_ = input.ReadInt32();
             break;
           }
         }
@@ -14839,7 +14862,7 @@ namespace Google.Protobuf.TestProtos {
         A.MergeFrom(other.A);
       }
       if (other.I != 0) {
-        I = other.I;
+        i_ = other.I;
       }
     }
 
@@ -14859,7 +14882,7 @@ namespace Google.Protobuf.TestProtos {
             break;
           }
           case 16: {
-            I = input.ReadInt32();
+            i_ = input.ReadInt32();
             break;
           }
         }
@@ -15120,7 +15143,7 @@ namespace Google.Protobuf.TestProtos {
         A.MergeFrom(other.A);
       }
       if (other.OptionalInt32 != 0) {
-        OptionalInt32 = other.OptionalInt32;
+        optionalInt32_ = other.OptionalInt32;
       }
     }
 
@@ -15140,7 +15163,7 @@ namespace Google.Protobuf.TestProtos {
             break;
           }
           case 16: {
-            OptionalInt32 = input.ReadInt32();
+            optionalInt32_ = input.ReadInt32();
             break;
           }
         }
@@ -15246,7 +15269,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Value != 0) {
-        Value = other.Value;
+        value_ = other.Value;
       }
     }
 
@@ -15492,13 +15515,13 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.PrimitiveField != 0) {
-        PrimitiveField = other.PrimitiveField;
+        primitiveField_ = other.PrimitiveField;
       }
       if (other.StringField.Length != 0) {
-        StringField = other.StringField;
+        stringField_ = other.StringField;
       }
       if (other.EnumField != 0) {
-        EnumField = other.EnumField;
+        enumField_ = other.EnumField;
       }
       if (other.messageField_ != null) {
         if (messageField_ == null) {
@@ -15521,11 +15544,11 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            PrimitiveField = input.ReadInt32();
+            primitiveField_ = input.ReadInt32();
             break;
           }
           case 18: {
-            StringField = input.ReadString();
+            stringField_ = input.ReadString();
             break;
           }
           case 24: {
@@ -15727,13 +15750,13 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.MyString.Length != 0) {
-        MyString = other.MyString;
+        myString_ = other.MyString;
       }
       if (other.MyInt != 0L) {
-        MyInt = other.MyInt;
+        myInt_ = other.MyInt;
       }
       if (other.MyFloat != 0F) {
-        MyFloat = other.MyFloat;
+        myFloat_ = other.MyFloat;
       }
       if (other.singleNestedMessage_ != null) {
         if (singleNestedMessage_ == null) {
@@ -15752,15 +15775,15 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            MyInt = input.ReadInt64();
+            myInt_ = input.ReadInt64();
             break;
           }
           case 90: {
-            MyString = input.ReadString();
+            myString_ = input.ReadString();
             break;
           }
           case 813: {
-            MyFloat = input.ReadFloat();
+            myFloat_ = input.ReadFloat();
             break;
           }
           case 1602: {
@@ -15901,10 +15924,10 @@ namespace Google.Protobuf.TestProtos {
             return;
           }
           if (other.Oo != 0L) {
-            Oo = other.Oo;
+            oo_ = other.Oo;
           }
           if (other.Bb != 0) {
-            Bb = other.Bb;
+            bb_ = other.Bb;
           }
         }
 
@@ -15917,11 +15940,11 @@ namespace Google.Protobuf.TestProtos {
                 input.SkipLastField();
                 break;
               case 8: {
-                Bb = input.ReadInt32();
+                bb_ = input.ReadInt32();
                 break;
               }
               case 16: {
-                Oo = input.ReadInt64();
+                oo_ = input.ReadInt64();
                 break;
               }
             }
@@ -16032,7 +16055,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.SparseEnum != 0) {
-        SparseEnum = other.SparseEnum;
+        sparseEnum_ = other.SparseEnum;
       }
     }
 
@@ -16154,7 +16177,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data.Length != 0) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -16167,7 +16190,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 10: {
-            Data = input.ReadString();
+            data_ = input.ReadString();
             break;
           }
         }
@@ -16384,7 +16407,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data.Length != 0) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -16397,7 +16420,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 10: {
-            Data = input.ReadBytes();
+            data_ = input.ReadBytes();
             break;
           }
         }
@@ -16503,7 +16526,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data.Length != 0) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -16516,7 +16539,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 10: {
-            Data = input.ReadBytes();
+            data_ = input.ReadBytes();
             break;
           }
         }
@@ -16625,7 +16648,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data != 0) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -16638,7 +16661,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            Data = input.ReadInt32();
+            data_ = input.ReadInt32();
             break;
           }
         }
@@ -16744,7 +16767,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data != 0) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -16757,7 +16780,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            Data = input.ReadUInt32();
+            data_ = input.ReadUInt32();
             break;
           }
         }
@@ -16863,7 +16886,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data != 0L) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -16876,7 +16899,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            Data = input.ReadInt64();
+            data_ = input.ReadInt64();
             break;
           }
         }
@@ -16982,7 +17005,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data != 0UL) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -16995,7 +17018,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            Data = input.ReadUInt64();
+            data_ = input.ReadUInt64();
             break;
           }
         }
@@ -17101,7 +17124,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.Data != false) {
-        Data = other.Data;
+        data_ = other.Data;
       }
     }
 
@@ -17114,7 +17137,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            Data = input.ReadBool();
+            data_ = input.ReadBool();
             break;
           }
         }
@@ -17321,11 +17344,13 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 8: {
-            FooInt = input.ReadInt32();
+            foo_ = input.ReadInt32();
+            fooCase_ = FooOneofCase.FooInt;
             break;
           }
           case 18: {
-            FooString = input.ReadString();
+            foo_ = input.ReadString();
+            fooCase_ = FooOneofCase.FooString;
             break;
           }
           case 26: {
@@ -17334,7 +17359,8 @@ namespace Google.Protobuf.TestProtos {
               subBuilder.MergeFrom(FooMessage);
             }
             input.ReadMessage(subBuilder);
-            FooMessage = subBuilder;
+            foo_ = subBuilder;
+            fooCase_ = FooOneofCase.FooMessage;
             break;
           }
         }
@@ -18448,7 +18474,7 @@ namespace Google.Protobuf.TestProtos {
         return;
       }
       if (other.A.Length != 0) {
-        A = other.A;
+        a_ = other.A;
       }
     }
 
@@ -18461,7 +18487,7 @@ namespace Google.Protobuf.TestProtos {
             input.SkipLastField();
             break;
           case 10: {
-            A = input.ReadString();
+            a_ = input.ReadString();
             break;
           }
         }

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/UpgradeTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/UpgradeTest.cs
@@ -210,7 +210,7 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.IntA != 0) {
-        IntA = other.IntA;
+        intA_ = other.IntA;
       }
     }
 
@@ -223,7 +223,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 8: {
-            IntA = input.ReadInt32();
+            intA_ = input.ReadInt32();
             break;
           }
         }
@@ -395,10 +395,10 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.IntA != 0) {
-        IntA = other.IntA;
+        intA_ = other.IntA;
       }
       if (other.IntB != 0) {
-        IntB = other.IntB;
+        intB_ = other.IntB;
       }
     }
 
@@ -411,11 +411,11 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 8: {
-            IntA = input.ReadInt32();
+            intA_ = input.ReadInt32();
             break;
           }
           case 16: {
-            IntB = input.ReadInt32();
+            intB_ = input.ReadInt32();
             break;
           }
         }
@@ -763,13 +763,13 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.LongA != 0L) {
-        LongA = other.LongA;
+        longA_ = other.LongA;
       }
       if (other.StrA.Length != 0) {
-        StrA = other.StrA;
+        strA_ = other.StrA;
       }
       if (other.EnumA != 0) {
-        EnumA = other.EnumA;
+        enumA_ = other.EnumA;
       }
       if (other.nestedA_ != null) {
         if (nestedA_ == null) {
@@ -797,11 +797,11 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 8: {
-            LongA = input.ReadInt64();
+            longA_ = input.ReadInt64();
             break;
           }
           case 18: {
-            StrA = input.ReadString();
+            strA_ = input.ReadString();
             break;
           }
           case 24: {
@@ -826,7 +826,8 @@ namespace Com.Zynga.Runtime.Protobuf {
             break;
           }
           case 61: {
-            FloatA = input.ReadFloat();
+            oneofA_ = input.ReadFloat();
+            oneofACase_ = OneofAOneofCase.FloatA;
             break;
           }
         }
@@ -1207,13 +1208,13 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.LongB != 0L) {
-        LongB = other.LongB;
+        longB_ = other.LongB;
       }
       if (other.StrB.Length != 0) {
-        StrB = other.StrB;
+        strB_ = other.StrB;
       }
       if (other.EnumB != 0) {
-        EnumB = other.EnumB;
+        enumB_ = other.EnumB;
       }
       if (other.nestedB_ != null) {
         if (nestedB_ == null) {
@@ -1241,11 +1242,11 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 8: {
-            LongB = input.ReadInt64();
+            longB_ = input.ReadInt64();
             break;
           }
           case 18: {
-            StrB = input.ReadString();
+            strB_ = input.ReadString();
             break;
           }
           case 24: {
@@ -1270,7 +1271,8 @@ namespace Com.Zynga.Runtime.Protobuf {
             break;
           }
           case 61: {
-            FloatB = input.ReadFloat();
+            oneofB_ = input.ReadFloat();
+            oneofBCase_ = OneofBOneofCase.FloatB;
             break;
           }
         }
@@ -1706,13 +1708,13 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.LongB != 0L) {
-        LongB = other.LongB;
+        longB_ = other.LongB;
       }
       if (other.StrB.Length != 0) {
-        StrB = other.StrB;
+        strB_ = other.StrB;
       }
       if (other.EnumB != 0) {
-        EnumB = other.EnumB;
+        enumB_ = other.EnumB;
       }
       if (other.nestedB_ != null) {
         if (nestedB_ == null) {
@@ -1724,7 +1726,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       listB_.Add(other.listB_);
       mapB_.Add(other.mapB_);
       if (other.LongC != 0L) {
-        LongC = other.LongC;
+        longC_ = other.LongC;
       }
       switch (other.OneofBCase) {
         case OneofBOneofCase.FloatB:
@@ -1746,11 +1748,11 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 8: {
-            LongB = input.ReadInt64();
+            longB_ = input.ReadInt64();
             break;
           }
           case 18: {
-            StrB = input.ReadString();
+            strB_ = input.ReadString();
             break;
           }
           case 24: {
@@ -1775,15 +1777,17 @@ namespace Com.Zynga.Runtime.Protobuf {
             break;
           }
           case 61: {
-            FloatB = input.ReadFloat();
+            oneofB_ = input.ReadFloat();
+            oneofBCase_ = OneofBOneofCase.FloatB;
             break;
           }
           case 64: {
-            LongC = input.ReadInt64();
+            longC_ = input.ReadInt64();
             break;
           }
           case 77: {
-            FloatC = input.ReadFloat();
+            oneofB_ = input.ReadFloat();
+            oneofBCase_ = OneofBOneofCase.FloatC;
             break;
           }
         }
@@ -2173,10 +2177,10 @@ namespace Com.Zynga.Runtime.Protobuf {
         return;
       }
       if (other.LongB != 0L) {
-        LongB = other.LongB;
+        longB_ = other.LongB;
       }
       if (other.EnumB != 0) {
-        EnumB = other.EnumB;
+        enumB_ = other.EnumB;
       }
       if (other.nestedB_ != null) {
         if (nestedB_ == null) {
@@ -2188,7 +2192,7 @@ namespace Com.Zynga.Runtime.Protobuf {
       listB_.Add(other.listB_);
       mapB_.Add(other.mapB_);
       if (other.LongC != 0L) {
-        LongC = other.LongC;
+        longC_ = other.LongC;
       }
       switch (other.OneofBCase) {
         case OneofBOneofCase.FloatC:
@@ -2207,7 +2211,7 @@ namespace Com.Zynga.Runtime.Protobuf {
             input.SkipLastField();
             break;
           case 8: {
-            LongB = input.ReadInt64();
+            longB_ = input.ReadInt64();
             break;
           }
           case 24: {
@@ -2232,11 +2236,12 @@ namespace Com.Zynga.Runtime.Protobuf {
             break;
           }
           case 64: {
-            LongC = input.ReadInt64();
+            longC_ = input.ReadInt64();
             break;
           }
           case 77: {
-            FloatC = input.ReadFloat();
+            oneofB_ = input.ReadFloat();
+            oneofBCase_ = OneofBOneofCase.FloatC;
             break;
           }
         }

--- a/runtime/src/Zynga.Protobuf.Runtime/Generated/EventSource.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/Generated/EventSource.cs
@@ -263,10 +263,10 @@ namespace Zynga.Protobuf.Runtime.EventSource {
         return;
       }
       if (other.ListAction != 0) {
-        ListAction = other.ListAction;
+        listAction_ = other.ListAction;
       }
       if (other.Index != 0) {
-        Index = other.Index;
+        index_ = other.Index;
       }
       if (other.content_ != null) {
         if (content_ == null) {
@@ -295,7 +295,7 @@ namespace Zynga.Protobuf.Runtime.EventSource {
             break;
           }
           case 16: {
-            Index = input.ReadInt32();
+            index_ = input.ReadInt32();
             break;
           }
           case 26: {
@@ -460,10 +460,10 @@ namespace Zynga.Protobuf.Runtime.EventSource {
         return;
       }
       if (other.MapAction != 0) {
-        MapAction = other.MapAction;
+        mapAction_ = other.MapAction;
       }
       if (other.KeyValue.Length != 0) {
-        KeyValue = other.KeyValue;
+        keyValue_ = other.KeyValue;
       }
       if (other.eventData_ != null) {
         if (eventData_ == null) {
@@ -486,7 +486,7 @@ namespace Zynga.Protobuf.Runtime.EventSource {
             break;
           }
           case 18: {
-            KeyValue = input.ReadBytes();
+            keyValue_ = input.ReadBytes();
             break;
           }
           case 26: {
@@ -840,7 +840,8 @@ namespace Zynga.Protobuf.Runtime.EventSource {
               subBuilder.MergeFrom(Set);
             }
             input.ReadMessage(subBuilder);
-            Set = subBuilder;
+            action_ = subBuilder;
+            actionCase_ = ActionOneofCase.Set;
             break;
           }
           case 26: {
@@ -849,7 +850,8 @@ namespace Zynga.Protobuf.Runtime.EventSource {
               subBuilder.MergeFrom(MapEvent);
             }
             input.ReadMessage(subBuilder);
-            MapEvent = subBuilder;
+            action_ = subBuilder;
+            actionCase_ = ActionOneofCase.MapEvent;
             break;
           }
           case 34: {
@@ -858,7 +860,8 @@ namespace Zynga.Protobuf.Runtime.EventSource {
               subBuilder.MergeFrom(ListEvent);
             }
             input.ReadMessage(subBuilder);
-            ListEvent = subBuilder;
+            action_ = subBuilder;
+            actionCase_ = ActionOneofCase.ListEvent;
             break;
           }
         }
@@ -1383,63 +1386,78 @@ namespace Zynga.Protobuf.Runtime.EventSource {
             input.SkipLastField();
             break;
           case 8: {
-            U32 = input.ReadUInt32();
+            data_ = input.ReadUInt32();
+            dataCase_ = DataOneofCase.U32;
             break;
           }
           case 16: {
-            I32 = input.ReadInt32();
+            data_ = input.ReadInt32();
+            dataCase_ = DataOneofCase.I32;
             break;
           }
           case 25: {
-            F64 = input.ReadFixed64();
+            data_ = input.ReadFixed64();
+            dataCase_ = DataOneofCase.F64;
             break;
           }
           case 37: {
-            F32 = input.ReadFixed32();
+            data_ = input.ReadFixed32();
+            dataCase_ = DataOneofCase.F32;
             break;
           }
           case 41: {
-            SF64 = input.ReadSFixed64();
+            data_ = input.ReadSFixed64();
+            dataCase_ = DataOneofCase.SF64;
             break;
           }
           case 53: {
-            SF32 = input.ReadSFixed32();
+            data_ = input.ReadSFixed32();
+            dataCase_ = DataOneofCase.SF32;
             break;
           }
           case 57: {
-            R64 = input.ReadDouble();
+            data_ = input.ReadDouble();
+            dataCase_ = DataOneofCase.R64;
             break;
           }
           case 69: {
-            R32 = input.ReadFloat();
+            data_ = input.ReadFloat();
+            dataCase_ = DataOneofCase.R32;
             break;
           }
           case 72: {
-            BoolData = input.ReadBool();
+            data_ = input.ReadBool();
+            dataCase_ = DataOneofCase.BoolData;
             break;
           }
           case 82: {
-            StringData = input.ReadString();
+            data_ = input.ReadString();
+            dataCase_ = DataOneofCase.StringData;
             break;
           }
           case 90: {
-            ByteData = input.ReadBytes();
+            data_ = input.ReadBytes();
+            dataCase_ = DataOneofCase.ByteData;
             break;
           }
           case 96: {
-            I64 = input.ReadInt64();
+            data_ = input.ReadInt64();
+            dataCase_ = DataOneofCase.I64;
             break;
           }
           case 104: {
-            U64 = input.ReadUInt64();
+            data_ = input.ReadUInt64();
+            dataCase_ = DataOneofCase.U64;
             break;
           }
           case 112: {
-            SI32 = input.ReadSInt32();
+            data_ = input.ReadSInt32();
+            dataCase_ = DataOneofCase.SI32;
             break;
           }
           case 120: {
-            SI64 = input.ReadSInt64();
+            data_ = input.ReadSInt64();
+            dataCase_ = DataOneofCase.SI64;
             break;
           }
         }


### PR DESCRIPTION
Previously when applying a snapshot, it would generate events for the fields that were being set.  This could result in an inconsistent state when replaying events.