### PR TITLE
Fixing issue with updating the index of repeated fields

### DIFF
--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/AllTypesTests.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/Simple/AllTypesTests.cs
@@ -753,5 +753,32 @@ namespace Zynga.Protobuf.Runtime.Tests.Simple {
 			Assert.Equal(target, target3);
 			Assert.NotEqual(allTypes, target3);
 		}
+
+		[Fact]
+		public void ShouldGenerateValidEventsForRepeatedFields() {
+			var allTypes = new TestAllTypes();
+			allTypes.RepeatedNestedMessage.Add(new TestAllTypes.Types.NestedMessage { Bb = 10 });
+			allTypes.RepeatedNestedMessage[0].Bb = 11;
+			allTypes.RepeatedNestedMessage[0].Bb = 12;
+			allTypes.RepeatedNestedMessage.RemoveAt(0);
+
+			allTypes.RepeatedNestedMessage.Add(new TestAllTypes.Types.NestedMessage { Bb = 13 });
+			allTypes.RepeatedNestedMessage.Add(new TestAllTypes.Types.NestedMessage { Bb = 14 });
+			allTypes.RepeatedNestedMessage.Add(new TestAllTypes.Types.NestedMessage { Bb = 15 });
+
+			allTypes.RepeatedNestedMessage[0].Bb = 16;
+			allTypes.RepeatedNestedMessage[0].Bb = 17;
+			allTypes.RepeatedNestedMessage.RemoveAt(0);
+
+			allTypes.RepeatedNestedMessage.Add(new TestAllTypes.Types.NestedMessage { Bb = 18 });
+			allTypes.RepeatedNestedMessage[0].Bb = 19;
+			allTypes.RepeatedNestedMessage[0].Bb = 20;
+
+			var events = allTypes.GenerateEvents();
+			var target = new TestAllTypes();
+			target.ApplyEvents(events);
+
+			Assert.Equal(allTypes, target);
+		}
 	}
 }

--- a/runtime/src/Zynga.Protobuf.Runtime/EventContext.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventContext.cs
@@ -226,5 +226,16 @@ namespace Zynga.Protobuf.Runtime {
 				_events.Add(e);
 			}
 		}
+
+		/// <summary>
+		/// Used for ListEventContext objects, which may have had their index updated by a replace or insert event
+		/// </summary>
+		/// <param name="index"></param>
+		public void TryUpdateContextIndex(int index) {
+			var listContext = _parent as ListEventContext;
+			if (listContext != null) {
+				listContext.Index = index;
+			}
+		}
 	}
 }

--- a/runtime/src/Zynga.Protobuf.Runtime/EventRegistry.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventRegistry.cs
@@ -129,10 +129,7 @@ namespace Zynga.Protobuf.Runtime {
 		/// </summary>
 		/// <param name="index"></param>
 		public void TryUpdateContextIndex(int index) {
-			var listContext = Context as ListEventContext;
-			if (listContext != null) {
-				listContext.Index = index;
-			}
+			Context.TryUpdateContextIndex(index);
 		}
 	}
 }


### PR DESCRIPTION
The parent context of the repeated field actually stores the index of the message.