### PR TITLE
Reduce heap allocations of EventPath

### DIFF
--- a/runtime/src/Zynga.Protobuf.Runtime/EventContext.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventContext.cs
@@ -77,7 +77,7 @@ namespace Zynga.Protobuf.Runtime {
 		/// Updates the path based on the parent path
 		/// </summary>
 		public void UpdatePath(EventPath parentPath) {
-			_path = new EventPath(parentPath, _path.Path[_path.Path.Count - 1]);
+			_path = new EventPath(parentPath, _path.Path[_path.Path.Length - 1]);
 			foreach (var child in _children) {
 				child.UpdatePath(_path);
 			}

--- a/runtime/src/Zynga.Protobuf.Runtime/EventPath.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventPath.cs
@@ -1,34 +1,32 @@
-using System.Collections.Generic;
+using System;
 
 namespace Zynga.Protobuf.Runtime {
 	/// <summary>
 	/// Used for generating event paths
 	/// </summary>
-	public class EventPath {
+	public struct EventPath {
 		/// <summary>
 		/// Generates an empty EventPath
 		/// </summary>
-		public static EventPath Empty => new EventPath();
+		public static EventPath Empty = new EventPath();
 
 		/// <summary>
 		/// The full path
 		/// </summary>
-		public List<int> Path { get; }
-
-		/// <summary>
-		/// Creates an empty EventPath
-		/// </summary>
-		public EventPath() {
-			Path = new List<int>();
-		}
+		public int[] Path;
 
 		/// <summary>
 		/// Create an EventPath for the child of another message
 		/// </summary>
 		public EventPath(EventPath parent, int field) {
-			Path = new List<int>(parent.Path.Count + 1);
-			Path.AddRange(parent.Path);
-			Path.Add(field);
+			if (parent.Path == null) {
+				Path = new[] {field};
+			}
+			else {
+				Path = new int[parent.Path.Length + 1];
+				Array.Copy(parent.Path, Path, parent.Path.Length);
+				Path[Path.Length - 1] = field;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Switched the EventPath class to a struct and the internal Path to an array.  In real world testing this has resulted in approx a 10% reduction in allocations and a 10 - 20% runtime speedup.