### PR TITLE
Changing how map keys are stored

### DIFF
--- a/proto/event_source.proto
+++ b/proto/event_source.proto
@@ -35,8 +35,9 @@ enum MapAction {
 
 message MapEvent {
   MapAction map_action = 1;
-  bytes     key_value  = 2;
-  EventData event_data = 3; // only used by update action
+  MapKey    key = 2;
+  bytes     key_value  = 3;
+  EventData event_data = 4; // only used by update action
 }
 
 message EventSourceRoot {
@@ -65,6 +66,23 @@ message EventContent {
     bool        bool_data   = 9;
     string      string_data = 10;
     bytes       byte_data   = 11;
+    int64       i_64        = 12;
+    uint64      u_64        = 13;
+    sint32      s_i_32      = 14;
+    sint64      s_i_64      = 15;
+  }
+}
+
+message MapKey {
+  oneof data {
+    uint32      u_32        = 1;
+    int32       i_32        = 2;
+    fixed64     f_64        = 3;
+    fixed32     f_32        = 4;
+    sfixed64    s_f_64      = 5;
+    sfixed32    s_f_32      = 6;
+    bool        bool_data   = 9;
+    string      string_data = 10;
     int64       i_64        = 12;
     uint64      u_64        = 13;
     sint32      s_i_32      = 14;

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/ComplexTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/ComplexTest.cs
@@ -574,26 +574,27 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     private static readonly pbc::MapField<string, global::Com.Zynga.Runtime.Protobuf.File.MessageC>.Codec _map_c_codec
         = new pbc::MapField<string, global::Com.Zynga.Runtime.Protobuf.File.MessageC>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::Com.Zynga.Runtime.Protobuf.File.MessageC.Parser), 18);
     internal class CMapConverter : EventMapConverter<string, global::Com.Zynga.Runtime.Protobuf.File.MessageC> {
-      public override ByteString GetKeyValue(string key, global::Com.Zynga.Runtime.Protobuf.File.MessageC value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(string key) {
+        return new zpr.EventSource.MapKey { StringData = key };
+      }
+      public override string GetKey(zpr.EventSource.MapKey key) {
+        return key.StringData;
+      }
+      public override ByteString GetKeyValue(string key, global::Com.Zynga.Runtime.Protobuf.File.MessageC value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteString(key);
-          if(!skipValue) dataStream.WriteMessage(value);
+          dataStream.WriteMessage(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.MessageC> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.MessageC> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeyc = dataStream.ReadString();
-        if (skipValue) {
-          return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.MessageC>(realKeyc, default(global::Com.Zynga.Runtime.Protobuf.File.MessageC));
-        }
-        else {
-          var realValuec = new global::Com.Zynga.Runtime.Protobuf.File.MessageC();
-          dataStream.ReadMessage(realValuec);;
-          return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.MessageC>(realKeyc, realValuec);
-        }
+        var realValuec = new global::Com.Zynga.Runtime.Protobuf.File.MessageC();
+        dataStream.ReadMessage(realValuec);;
+        return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.MessageC>(realKeyc, realValuec);
       }
     }
     private static readonly EventMapConverter<string, global::Com.Zynga.Runtime.Protobuf.File.MessageC> cMapConverter = new CMapConverter();
@@ -972,26 +973,27 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     private static readonly pbc::MapField<string, global::Com.Zynga.Runtime.Protobuf.File.MessageD>.Codec _map_d_codec
         = new pbc::MapField<string, global::Com.Zynga.Runtime.Protobuf.File.MessageD>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::Com.Zynga.Runtime.Protobuf.File.MessageD.Parser), 26);
     internal class DMapConverter : EventMapConverter<string, global::Com.Zynga.Runtime.Protobuf.File.MessageD> {
-      public override ByteString GetKeyValue(string key, global::Com.Zynga.Runtime.Protobuf.File.MessageD value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(string key) {
+        return new zpr.EventSource.MapKey { StringData = key };
+      }
+      public override string GetKey(zpr.EventSource.MapKey key) {
+        return key.StringData;
+      }
+      public override ByteString GetKeyValue(string key, global::Com.Zynga.Runtime.Protobuf.File.MessageD value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteString(key);
-          if(!skipValue) dataStream.WriteMessage(value);
+          dataStream.WriteMessage(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.MessageD> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.MessageD> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeyd = dataStream.ReadString();
-        if (skipValue) {
-          return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.MessageD>(realKeyd, default(global::Com.Zynga.Runtime.Protobuf.File.MessageD));
-        }
-        else {
-          var realValued = new global::Com.Zynga.Runtime.Protobuf.File.MessageD();
-          dataStream.ReadMessage(realValued);;
-          return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.MessageD>(realKeyd, realValued);
-        }
+        var realValued = new global::Com.Zynga.Runtime.Protobuf.File.MessageD();
+        dataStream.ReadMessage(realValued);;
+        return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.MessageD>(realKeyd, realValued);
       }
     }
     private static readonly EventMapConverter<string, global::Com.Zynga.Runtime.Protobuf.File.MessageD> dMapConverter = new DMapConverter();

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/DeltaTest.cs
@@ -226,25 +226,26 @@ namespace Com.Zynga.Runtime.Protobuf {
     private static readonly pbc::MapField<int, string>.Codec _map_intToString_codec
         = new pbc::MapField<int, string>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForString(18), 26);
     internal class IntToStringMapConverter : EventMapConverter<int, string> {
-      public override ByteString GetKeyValue(int key, string value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, string value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteString(value);
+          dataStream.WriteString(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, string> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, string> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeyintToString = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, string>(realKeyintToString, default(string));
-        }
-        else {
-          var realValueintToString = dataStream.ReadString();
-          return new KeyValuePair<int, string>(realKeyintToString, realValueintToString);
-        }
+        var realValueintToString = dataStream.ReadString();
+        return new KeyValuePair<int, string>(realKeyintToString, realValueintToString);
       }
     }
     private static readonly EventMapConverter<int, string> intToStringMapConverter = new IntToStringMapConverter();
@@ -259,26 +260,27 @@ namespace Com.Zynga.Runtime.Protobuf {
     private static readonly pbc::MapField<string, global::Com.Zynga.Runtime.Protobuf.Foo>.Codec _map_stringToFoo_codec
         = new pbc::MapField<string, global::Com.Zynga.Runtime.Protobuf.Foo>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::Com.Zynga.Runtime.Protobuf.Foo.Parser), 34);
     internal class StringToFooMapConverter : EventMapConverter<string, global::Com.Zynga.Runtime.Protobuf.Foo> {
-      public override ByteString GetKeyValue(string key, global::Com.Zynga.Runtime.Protobuf.Foo value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(string key) {
+        return new zpr.EventSource.MapKey { StringData = key };
+      }
+      public override string GetKey(zpr.EventSource.MapKey key) {
+        return key.StringData;
+      }
+      public override ByteString GetKeyValue(string key, global::Com.Zynga.Runtime.Protobuf.Foo value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteString(key);
-          if(!skipValue) dataStream.WriteMessage(value);
+          dataStream.WriteMessage(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.Foo> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.Foo> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeystringToFoo = dataStream.ReadString();
-        if (skipValue) {
-          return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.Foo>(realKeystringToFoo, default(global::Com.Zynga.Runtime.Protobuf.Foo));
-        }
-        else {
-          var realValuestringToFoo = new global::Com.Zynga.Runtime.Protobuf.Foo();
-          dataStream.ReadMessage(realValuestringToFoo);;
-          return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.Foo>(realKeystringToFoo, realValuestringToFoo);
-        }
+        var realValuestringToFoo = new global::Com.Zynga.Runtime.Protobuf.Foo();
+        dataStream.ReadMessage(realValuestringToFoo);;
+        return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.Foo>(realKeystringToFoo, realValuestringToFoo);
       }
     }
     private static readonly EventMapConverter<string, global::Com.Zynga.Runtime.Protobuf.Foo> stringToFooMapConverter = new StringToFooMapConverter();
@@ -2402,26 +2404,27 @@ namespace Com.Zynga.Runtime.Protobuf {
     private static readonly pbc::MapField<int, global::Com.Zynga.Runtime.Protobuf.RecursiveMap>.Codec _map_map_codec
         = new pbc::MapField<int, global::Com.Zynga.Runtime.Protobuf.RecursiveMap>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForMessage(18, global::Com.Zynga.Runtime.Protobuf.RecursiveMap.Parser), 10);
     internal class MapMapConverter : EventMapConverter<int, global::Com.Zynga.Runtime.Protobuf.RecursiveMap> {
-      public override ByteString GetKeyValue(int key, global::Com.Zynga.Runtime.Protobuf.RecursiveMap value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, global::Com.Zynga.Runtime.Protobuf.RecursiveMap value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteMessage(value);
+          dataStream.WriteMessage(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, global::Com.Zynga.Runtime.Protobuf.RecursiveMap> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, global::Com.Zynga.Runtime.Protobuf.RecursiveMap> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymap = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, global::Com.Zynga.Runtime.Protobuf.RecursiveMap>(realKeymap, default(global::Com.Zynga.Runtime.Protobuf.RecursiveMap));
-        }
-        else {
-          var realValuemap = new global::Com.Zynga.Runtime.Protobuf.RecursiveMap();
-          dataStream.ReadMessage(realValuemap);;
-          return new KeyValuePair<int, global::Com.Zynga.Runtime.Protobuf.RecursiveMap>(realKeymap, realValuemap);
-        }
+        var realValuemap = new global::Com.Zynga.Runtime.Protobuf.RecursiveMap();
+        dataStream.ReadMessage(realValuemap);;
+        return new KeyValuePair<int, global::Com.Zynga.Runtime.Protobuf.RecursiveMap>(realKeymap, realValuemap);
       }
     }
     private static readonly EventMapConverter<int, global::Com.Zynga.Runtime.Protobuf.RecursiveMap> mapMapConverter = new MapMapConverter();

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/EventTest.cs
@@ -580,26 +580,27 @@ namespace Com.Zynga.Runtime.Protobuf {
     private static readonly pbc::MapField<string, global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage>.Codec _map_testMap_codec
         = new pbc::MapField<string, global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage.Parser), 66);
     internal class TestMapMapConverter : EventMapConverter<string, global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage> {
-      public override ByteString GetKeyValue(string key, global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(string key) {
+        return new zpr.EventSource.MapKey { StringData = key };
+      }
+      public override string GetKey(zpr.EventSource.MapKey key) {
+        return key.StringData;
+      }
+      public override ByteString GetKeyValue(string key, global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteString(key);
-          if(!skipValue) dataStream.WriteMessage(value);
+          dataStream.WriteMessage(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeytestMap = dataStream.ReadString();
-        if (skipValue) {
-          return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage>(realKeytestMap, default(global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage));
-        }
-        else {
-          var realValuetestMap = new global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage();
-          dataStream.ReadMessage(realValuetestMap);;
-          return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage>(realKeytestMap, realValuetestMap);
-        }
+        var realValuetestMap = new global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage();
+        dataStream.ReadMessage(realValuetestMap);;
+        return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage>(realKeytestMap, realValuetestMap);
       }
     }
     private static readonly EventMapConverter<string, global::Com.Zynga.Runtime.Protobuf.EventTest.Types.NestedMessage> testMapMapConverter = new TestMapMapConverter();
@@ -632,25 +633,26 @@ namespace Com.Zynga.Runtime.Protobuf {
     private static readonly pbc::MapField<int, string>.Codec _map_testMapTwo_codec
         = new pbc::MapField<int, string>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForString(18), 82);
     internal class TestMapTwoMapConverter : EventMapConverter<int, string> {
-      public override ByteString GetKeyValue(int key, string value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, string value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteString(value);
+          dataStream.WriteString(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, string> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, string> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeytestMapTwo = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, string>(realKeytestMapTwo, default(string));
-        }
-        else {
-          var realValuetestMapTwo = dataStream.ReadString();
-          return new KeyValuePair<int, string>(realKeytestMapTwo, realValuetestMapTwo);
-        }
+        var realValuetestMapTwo = dataStream.ReadString();
+        return new KeyValuePair<int, string>(realKeytestMapTwo, realValuetestMapTwo);
       }
     }
     private static readonly EventMapConverter<int, string> testMapTwoMapConverter = new TestMapTwoMapConverter();

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/FileTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/FileTest.cs
@@ -240,25 +240,26 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     private static readonly pbc::MapField<int, string>.Codec _map_intToString_codec
         = new pbc::MapField<int, string>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForString(18), 26);
     internal class IntToStringMapConverter : EventMapConverter<int, string> {
-      public override ByteString GetKeyValue(int key, string value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, string value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteString(value);
+          dataStream.WriteString(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, string> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, string> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeyintToString = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, string>(realKeyintToString, default(string));
-        }
-        else {
-          var realValueintToString = dataStream.ReadString();
-          return new KeyValuePair<int, string>(realKeyintToString, realValueintToString);
-        }
+        var realValueintToString = dataStream.ReadString();
+        return new KeyValuePair<int, string>(realKeyintToString, realValueintToString);
       }
     }
     private static readonly EventMapConverter<int, string> intToStringMapConverter = new IntToStringMapConverter();
@@ -273,26 +274,27 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     private static readonly pbc::MapField<string, global::Com.Zynga.Runtime.Protobuf.File.Foo>.Codec _map_stringToFoo_codec
         = new pbc::MapField<string, global::Com.Zynga.Runtime.Protobuf.File.Foo>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForMessage(18, global::Com.Zynga.Runtime.Protobuf.File.Foo.Parser), 34);
     internal class StringToFooMapConverter : EventMapConverter<string, global::Com.Zynga.Runtime.Protobuf.File.Foo> {
-      public override ByteString GetKeyValue(string key, global::Com.Zynga.Runtime.Protobuf.File.Foo value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(string key) {
+        return new zpr.EventSource.MapKey { StringData = key };
+      }
+      public override string GetKey(zpr.EventSource.MapKey key) {
+        return key.StringData;
+      }
+      public override ByteString GetKeyValue(string key, global::Com.Zynga.Runtime.Protobuf.File.Foo value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteString(key);
-          if(!skipValue) dataStream.WriteMessage(value);
+          dataStream.WriteMessage(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.Foo> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.Foo> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeystringToFoo = dataStream.ReadString();
-        if (skipValue) {
-          return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.Foo>(realKeystringToFoo, default(global::Com.Zynga.Runtime.Protobuf.File.Foo));
-        }
-        else {
-          var realValuestringToFoo = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
-          dataStream.ReadMessage(realValuestringToFoo);;
-          return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.Foo>(realKeystringToFoo, realValuestringToFoo);
-        }
+        var realValuestringToFoo = new global::Com.Zynga.Runtime.Protobuf.File.Foo();
+        dataStream.ReadMessage(realValuestringToFoo);;
+        return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.File.Foo>(realKeystringToFoo, realValuestringToFoo);
       }
     }
     private static readonly EventMapConverter<string, global::Com.Zynga.Runtime.Protobuf.File.Foo> stringToFooMapConverter = new StringToFooMapConverter();
@@ -2578,26 +2580,27 @@ namespace Com.Zynga.Runtime.Protobuf.File {
     private static readonly pbc::MapField<int, global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap>.Codec _map_map_codec
         = new pbc::MapField<int, global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForMessage(18, global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap.Parser), 10);
     internal class MapMapConverter : EventMapConverter<int, global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap> {
-      public override ByteString GetKeyValue(int key, global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteMessage(value);
+          dataStream.WriteMessage(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymap = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap>(realKeymap, default(global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap));
-        }
-        else {
-          var realValuemap = new global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap();
-          dataStream.ReadMessage(realValuemap);;
-          return new KeyValuePair<int, global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap>(realKeymap, realValuemap);
-        }
+        var realValuemap = new global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap();
+        dataStream.ReadMessage(realValuemap);;
+        return new KeyValuePair<int, global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap>(realKeymap, realValuemap);
       }
     }
     private static readonly EventMapConverter<int, global::Com.Zynga.Runtime.Protobuf.File.RecursiveMap> mapMapConverter = new MapMapConverter();

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMap.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/SimpleMap.cs
@@ -539,26 +539,27 @@ namespace Com.Zynga.Runtime.Protobuf {
     private static readonly pbc::MapField<long, global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage>.Codec _map_testFoo_codec
         = new pbc::MapField<long, global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage>.Codec(pb::FieldCodec.ForInt64(8), pb::FieldCodec.ForMessage(18, global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage.Parser), 82);
     internal class TestFooMapConverter : EventMapConverter<long, global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage> {
-      public override ByteString GetKeyValue(long key, global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(long key) {
+        return new zpr.EventSource.MapKey { I64 = key };
+      }
+      public override long GetKey(zpr.EventSource.MapKey key) {
+        return key.I64;
+      }
+      public override ByteString GetKeyValue(long key, global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt64(key);
-          if(!skipValue) dataStream.WriteMessage(value);
+          dataStream.WriteMessage(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<long, global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<long, global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeytestFoo = dataStream.ReadInt64();
-        if (skipValue) {
-          return new KeyValuePair<long, global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage>(realKeytestFoo, default(global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage));
-        }
-        else {
-          var realValuetestFoo = new global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage();
-          dataStream.ReadMessage(realValuetestFoo);;
-          return new KeyValuePair<long, global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage>(realKeytestFoo, realValuetestFoo);
-        }
+        var realValuetestFoo = new global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage();
+        dataStream.ReadMessage(realValuetestFoo);;
+        return new KeyValuePair<long, global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage>(realKeytestFoo, realValuetestFoo);
       }
     }
     private static readonly EventMapConverter<long, global::Com.Zynga.Runtime.Protobuf.SimpleMapDeltaMessage> testFooMapConverter = new TestFooMapConverter();
@@ -823,25 +824,26 @@ namespace Com.Zynga.Runtime.Protobuf {
     private static readonly pbc::MapField<string, global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum>.Codec _map_testFoo_codec
         = new pbc::MapField<string, global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForEnum(16, x => (int) x, x => (global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum) x), 82);
     internal class TestFooMapConverter : EventMapConverter<string, global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum> {
-      public override ByteString GetKeyValue(string key, global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(string key) {
+        return new zpr.EventSource.MapKey { StringData = key };
+      }
+      public override string GetKey(zpr.EventSource.MapKey key) {
+        return key.StringData;
+      }
+      public override ByteString GetKeyValue(string key, global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteString(key);
-          if(!skipValue) dataStream.WriteEnum((int) value);
+          dataStream.WriteEnum((int) value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeytestFoo = dataStream.ReadString();
-        if (skipValue) {
-          return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum>(realKeytestFoo, default(global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum));
-        }
-        else {
-          var realValuetestFoo = (global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum) dataStream.ReadEnum();
-          return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum>(realKeytestFoo, realValuetestFoo);
-        }
+        var realValuetestFoo = (global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum) dataStream.ReadEnum();
+        return new KeyValuePair<string, global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum>(realKeytestFoo, realValuetestFoo);
       }
     }
     private static readonly EventMapConverter<string, global::Com.Zynga.Runtime.Protobuf.SimpleMapEnum> testFooMapConverter = new TestFooMapConverter();
@@ -1106,25 +1108,26 @@ namespace Com.Zynga.Runtime.Protobuf {
     private static readonly pbc::MapField<string, string>.Codec _map_testFoo_codec
         = new pbc::MapField<string, string>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForString(18), 82);
     internal class TestFooMapConverter : EventMapConverter<string, string> {
-      public override ByteString GetKeyValue(string key, string value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(string key) {
+        return new zpr.EventSource.MapKey { StringData = key };
+      }
+      public override string GetKey(zpr.EventSource.MapKey key) {
+        return key.StringData;
+      }
+      public override ByteString GetKeyValue(string key, string value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteString(key);
-          if(!skipValue) dataStream.WriteString(value);
+          dataStream.WriteString(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<string, string> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<string, string> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeytestFoo = dataStream.ReadString();
-        if (skipValue) {
-          return new KeyValuePair<string, string>(realKeytestFoo, default(string));
-        }
-        else {
-          var realValuetestFoo = dataStream.ReadString();
-          return new KeyValuePair<string, string>(realKeytestFoo, realValuetestFoo);
-        }
+        var realValuetestFoo = dataStream.ReadString();
+        return new KeyValuePair<string, string>(realKeytestFoo, realValuetestFoo);
       }
     }
     private static readonly EventMapConverter<string, string> testFooMapConverter = new TestFooMapConverter();
@@ -1389,25 +1392,26 @@ namespace Com.Zynga.Runtime.Protobuf {
     private static readonly pbc::MapField<string, long>.Codec _map_testFoo_codec
         = new pbc::MapField<string, long>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForInt64(16), 82);
     internal class TestFooMapConverter : EventMapConverter<string, long> {
-      public override ByteString GetKeyValue(string key, long value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(string key) {
+        return new zpr.EventSource.MapKey { StringData = key };
+      }
+      public override string GetKey(zpr.EventSource.MapKey key) {
+        return key.StringData;
+      }
+      public override ByteString GetKeyValue(string key, long value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteString(key);
-          if(!skipValue) dataStream.WriteInt64(value);
+          dataStream.WriteInt64(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<string, long> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<string, long> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeytestFoo = dataStream.ReadString();
-        if (skipValue) {
-          return new KeyValuePair<string, long>(realKeytestFoo, default(long));
-        }
-        else {
-          var realValuetestFoo = dataStream.ReadInt64();
-          return new KeyValuePair<string, long>(realKeytestFoo, realValuetestFoo);
-        }
+        var realValuetestFoo = dataStream.ReadInt64();
+        return new KeyValuePair<string, long>(realKeytestFoo, realValuetestFoo);
       }
     }
     private static readonly EventMapConverter<string, long> testFooMapConverter = new TestFooMapConverter();

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/UnittestProto3.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/UnittestProto3.cs
@@ -1984,25 +1984,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<int, int>.Codec _map_mapInt32Int32_codec
         = new pbc::MapField<int, int>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForInt32(16), 922);
     internal class MapInt32Int32MapConverter : EventMapConverter<int, int> {
-      public override ByteString GetKeyValue(int key, int value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, int value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteInt32(value);
+          dataStream.WriteInt32(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, int> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, int> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapInt32Int32 = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, int>(realKeymapInt32Int32, default(int));
-        }
-        else {
-          var realValuemapInt32Int32 = dataStream.ReadInt32();
-          return new KeyValuePair<int, int>(realKeymapInt32Int32, realValuemapInt32Int32);
-        }
+        var realValuemapInt32Int32 = dataStream.ReadInt32();
+        return new KeyValuePair<int, int>(realKeymapInt32Int32, realValuemapInt32Int32);
       }
     }
     private static readonly EventMapConverter<int, int> mapInt32Int32MapConverter = new MapInt32Int32MapConverter();
@@ -2017,25 +2018,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<long, long>.Codec _map_mapInt64Int64_codec
         = new pbc::MapField<long, long>.Codec(pb::FieldCodec.ForInt64(8), pb::FieldCodec.ForInt64(16), 930);
     internal class MapInt64Int64MapConverter : EventMapConverter<long, long> {
-      public override ByteString GetKeyValue(long key, long value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(long key) {
+        return new zpr.EventSource.MapKey { I64 = key };
+      }
+      public override long GetKey(zpr.EventSource.MapKey key) {
+        return key.I64;
+      }
+      public override ByteString GetKeyValue(long key, long value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt64(key);
-          if(!skipValue) dataStream.WriteInt64(value);
+          dataStream.WriteInt64(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<long, long> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<long, long> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapInt64Int64 = dataStream.ReadInt64();
-        if (skipValue) {
-          return new KeyValuePair<long, long>(realKeymapInt64Int64, default(long));
-        }
-        else {
-          var realValuemapInt64Int64 = dataStream.ReadInt64();
-          return new KeyValuePair<long, long>(realKeymapInt64Int64, realValuemapInt64Int64);
-        }
+        var realValuemapInt64Int64 = dataStream.ReadInt64();
+        return new KeyValuePair<long, long>(realKeymapInt64Int64, realValuemapInt64Int64);
       }
     }
     private static readonly EventMapConverter<long, long> mapInt64Int64MapConverter = new MapInt64Int64MapConverter();
@@ -2050,25 +2052,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<uint, uint>.Codec _map_mapUint32Uint32_codec
         = new pbc::MapField<uint, uint>.Codec(pb::FieldCodec.ForUInt32(8), pb::FieldCodec.ForUInt32(16), 938);
     internal class MapUint32Uint32MapConverter : EventMapConverter<uint, uint> {
-      public override ByteString GetKeyValue(uint key, uint value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(uint key) {
+        return new zpr.EventSource.MapKey { U32 = key };
+      }
+      public override uint GetKey(zpr.EventSource.MapKey key) {
+        return key.U32;
+      }
+      public override ByteString GetKeyValue(uint key, uint value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteUInt32(key);
-          if(!skipValue) dataStream.WriteUInt32(value);
+          dataStream.WriteUInt32(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<uint, uint> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<uint, uint> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapUint32Uint32 = dataStream.ReadUInt32();
-        if (skipValue) {
-          return new KeyValuePair<uint, uint>(realKeymapUint32Uint32, default(uint));
-        }
-        else {
-          var realValuemapUint32Uint32 = dataStream.ReadUInt32();
-          return new KeyValuePair<uint, uint>(realKeymapUint32Uint32, realValuemapUint32Uint32);
-        }
+        var realValuemapUint32Uint32 = dataStream.ReadUInt32();
+        return new KeyValuePair<uint, uint>(realKeymapUint32Uint32, realValuemapUint32Uint32);
       }
     }
     private static readonly EventMapConverter<uint, uint> mapUint32Uint32MapConverter = new MapUint32Uint32MapConverter();
@@ -2083,25 +2086,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<ulong, ulong>.Codec _map_mapUint64Uint64_codec
         = new pbc::MapField<ulong, ulong>.Codec(pb::FieldCodec.ForUInt64(8), pb::FieldCodec.ForUInt64(16), 946);
     internal class MapUint64Uint64MapConverter : EventMapConverter<ulong, ulong> {
-      public override ByteString GetKeyValue(ulong key, ulong value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(ulong key) {
+        return new zpr.EventSource.MapKey { U64 = key };
+      }
+      public override ulong GetKey(zpr.EventSource.MapKey key) {
+        return key.U64;
+      }
+      public override ByteString GetKeyValue(ulong key, ulong value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteUInt64(key);
-          if(!skipValue) dataStream.WriteUInt64(value);
+          dataStream.WriteUInt64(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<ulong, ulong> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<ulong, ulong> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapUint64Uint64 = dataStream.ReadUInt64();
-        if (skipValue) {
-          return new KeyValuePair<ulong, ulong>(realKeymapUint64Uint64, default(ulong));
-        }
-        else {
-          var realValuemapUint64Uint64 = dataStream.ReadUInt64();
-          return new KeyValuePair<ulong, ulong>(realKeymapUint64Uint64, realValuemapUint64Uint64);
-        }
+        var realValuemapUint64Uint64 = dataStream.ReadUInt64();
+        return new KeyValuePair<ulong, ulong>(realKeymapUint64Uint64, realValuemapUint64Uint64);
       }
     }
     private static readonly EventMapConverter<ulong, ulong> mapUint64Uint64MapConverter = new MapUint64Uint64MapConverter();
@@ -2116,25 +2120,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<int, int>.Codec _map_mapSint32Sint32_codec
         = new pbc::MapField<int, int>.Codec(pb::FieldCodec.ForSInt32(8), pb::FieldCodec.ForSInt32(16), 954);
     internal class MapSint32Sint32MapConverter : EventMapConverter<int, int> {
-      public override ByteString GetKeyValue(int key, int value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { SI32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.SI32;
+      }
+      public override ByteString GetKeyValue(int key, int value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteSInt32(key);
-          if(!skipValue) dataStream.WriteSInt32(value);
+          dataStream.WriteSInt32(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, int> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, int> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapSint32Sint32 = dataStream.ReadSInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, int>(realKeymapSint32Sint32, default(int));
-        }
-        else {
-          var realValuemapSint32Sint32 = dataStream.ReadSInt32();
-          return new KeyValuePair<int, int>(realKeymapSint32Sint32, realValuemapSint32Sint32);
-        }
+        var realValuemapSint32Sint32 = dataStream.ReadSInt32();
+        return new KeyValuePair<int, int>(realKeymapSint32Sint32, realValuemapSint32Sint32);
       }
     }
     private static readonly EventMapConverter<int, int> mapSint32Sint32MapConverter = new MapSint32Sint32MapConverter();
@@ -2149,25 +2154,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<long, long>.Codec _map_mapSint64Sint64_codec
         = new pbc::MapField<long, long>.Codec(pb::FieldCodec.ForSInt64(8), pb::FieldCodec.ForSInt64(16), 962);
     internal class MapSint64Sint64MapConverter : EventMapConverter<long, long> {
-      public override ByteString GetKeyValue(long key, long value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(long key) {
+        return new zpr.EventSource.MapKey { SI64 = key };
+      }
+      public override long GetKey(zpr.EventSource.MapKey key) {
+        return key.SI64;
+      }
+      public override ByteString GetKeyValue(long key, long value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteSInt64(key);
-          if(!skipValue) dataStream.WriteSInt64(value);
+          dataStream.WriteSInt64(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<long, long> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<long, long> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapSint64Sint64 = dataStream.ReadSInt64();
-        if (skipValue) {
-          return new KeyValuePair<long, long>(realKeymapSint64Sint64, default(long));
-        }
-        else {
-          var realValuemapSint64Sint64 = dataStream.ReadSInt64();
-          return new KeyValuePair<long, long>(realKeymapSint64Sint64, realValuemapSint64Sint64);
-        }
+        var realValuemapSint64Sint64 = dataStream.ReadSInt64();
+        return new KeyValuePair<long, long>(realKeymapSint64Sint64, realValuemapSint64Sint64);
       }
     }
     private static readonly EventMapConverter<long, long> mapSint64Sint64MapConverter = new MapSint64Sint64MapConverter();
@@ -2182,25 +2188,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<uint, uint>.Codec _map_mapFixed32Fixed32_codec
         = new pbc::MapField<uint, uint>.Codec(pb::FieldCodec.ForFixed32(13), pb::FieldCodec.ForFixed32(21), 970);
     internal class MapFixed32Fixed32MapConverter : EventMapConverter<uint, uint> {
-      public override ByteString GetKeyValue(uint key, uint value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(uint key) {
+        return new zpr.EventSource.MapKey { F32 = key };
+      }
+      public override uint GetKey(zpr.EventSource.MapKey key) {
+        return key.F32;
+      }
+      public override ByteString GetKeyValue(uint key, uint value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteFixed32(key);
-          if(!skipValue) dataStream.WriteFixed32(value);
+          dataStream.WriteFixed32(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<uint, uint> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<uint, uint> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapFixed32Fixed32 = dataStream.ReadFixed32();
-        if (skipValue) {
-          return new KeyValuePair<uint, uint>(realKeymapFixed32Fixed32, default(uint));
-        }
-        else {
-          var realValuemapFixed32Fixed32 = dataStream.ReadFixed32();
-          return new KeyValuePair<uint, uint>(realKeymapFixed32Fixed32, realValuemapFixed32Fixed32);
-        }
+        var realValuemapFixed32Fixed32 = dataStream.ReadFixed32();
+        return new KeyValuePair<uint, uint>(realKeymapFixed32Fixed32, realValuemapFixed32Fixed32);
       }
     }
     private static readonly EventMapConverter<uint, uint> mapFixed32Fixed32MapConverter = new MapFixed32Fixed32MapConverter();
@@ -2215,25 +2222,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<ulong, ulong>.Codec _map_mapFixed64Fixed64_codec
         = new pbc::MapField<ulong, ulong>.Codec(pb::FieldCodec.ForFixed64(9), pb::FieldCodec.ForFixed64(17), 978);
     internal class MapFixed64Fixed64MapConverter : EventMapConverter<ulong, ulong> {
-      public override ByteString GetKeyValue(ulong key, ulong value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(ulong key) {
+        return new zpr.EventSource.MapKey { F64 = key };
+      }
+      public override ulong GetKey(zpr.EventSource.MapKey key) {
+        return key.F64;
+      }
+      public override ByteString GetKeyValue(ulong key, ulong value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteFixed64(key);
-          if(!skipValue) dataStream.WriteFixed64(value);
+          dataStream.WriteFixed64(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<ulong, ulong> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<ulong, ulong> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapFixed64Fixed64 = dataStream.ReadFixed64();
-        if (skipValue) {
-          return new KeyValuePair<ulong, ulong>(realKeymapFixed64Fixed64, default(ulong));
-        }
-        else {
-          var realValuemapFixed64Fixed64 = dataStream.ReadFixed64();
-          return new KeyValuePair<ulong, ulong>(realKeymapFixed64Fixed64, realValuemapFixed64Fixed64);
-        }
+        var realValuemapFixed64Fixed64 = dataStream.ReadFixed64();
+        return new KeyValuePair<ulong, ulong>(realKeymapFixed64Fixed64, realValuemapFixed64Fixed64);
       }
     }
     private static readonly EventMapConverter<ulong, ulong> mapFixed64Fixed64MapConverter = new MapFixed64Fixed64MapConverter();
@@ -2248,25 +2256,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<int, int>.Codec _map_mapSfixed32Sfixed32_codec
         = new pbc::MapField<int, int>.Codec(pb::FieldCodec.ForSFixed32(13), pb::FieldCodec.ForSFixed32(21), 986);
     internal class MapSfixed32Sfixed32MapConverter : EventMapConverter<int, int> {
-      public override ByteString GetKeyValue(int key, int value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { SF32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.SF32;
+      }
+      public override ByteString GetKeyValue(int key, int value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteSFixed32(key);
-          if(!skipValue) dataStream.WriteSFixed32(value);
+          dataStream.WriteSFixed32(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, int> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, int> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapSfixed32Sfixed32 = dataStream.ReadSFixed32();
-        if (skipValue) {
-          return new KeyValuePair<int, int>(realKeymapSfixed32Sfixed32, default(int));
-        }
-        else {
-          var realValuemapSfixed32Sfixed32 = dataStream.ReadSFixed32();
-          return new KeyValuePair<int, int>(realKeymapSfixed32Sfixed32, realValuemapSfixed32Sfixed32);
-        }
+        var realValuemapSfixed32Sfixed32 = dataStream.ReadSFixed32();
+        return new KeyValuePair<int, int>(realKeymapSfixed32Sfixed32, realValuemapSfixed32Sfixed32);
       }
     }
     private static readonly EventMapConverter<int, int> mapSfixed32Sfixed32MapConverter = new MapSfixed32Sfixed32MapConverter();
@@ -2281,25 +2290,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<long, long>.Codec _map_mapSfixed64Sfixed64_codec
         = new pbc::MapField<long, long>.Codec(pb::FieldCodec.ForSFixed64(9), pb::FieldCodec.ForSFixed64(17), 994);
     internal class MapSfixed64Sfixed64MapConverter : EventMapConverter<long, long> {
-      public override ByteString GetKeyValue(long key, long value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(long key) {
+        return new zpr.EventSource.MapKey { SF64 = key };
+      }
+      public override long GetKey(zpr.EventSource.MapKey key) {
+        return key.SF64;
+      }
+      public override ByteString GetKeyValue(long key, long value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteSFixed64(key);
-          if(!skipValue) dataStream.WriteSFixed64(value);
+          dataStream.WriteSFixed64(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<long, long> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<long, long> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapSfixed64Sfixed64 = dataStream.ReadSFixed64();
-        if (skipValue) {
-          return new KeyValuePair<long, long>(realKeymapSfixed64Sfixed64, default(long));
-        }
-        else {
-          var realValuemapSfixed64Sfixed64 = dataStream.ReadSFixed64();
-          return new KeyValuePair<long, long>(realKeymapSfixed64Sfixed64, realValuemapSfixed64Sfixed64);
-        }
+        var realValuemapSfixed64Sfixed64 = dataStream.ReadSFixed64();
+        return new KeyValuePair<long, long>(realKeymapSfixed64Sfixed64, realValuemapSfixed64Sfixed64);
       }
     }
     private static readonly EventMapConverter<long, long> mapSfixed64Sfixed64MapConverter = new MapSfixed64Sfixed64MapConverter();
@@ -2314,25 +2324,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<int, float>.Codec _map_mapInt32Float_codec
         = new pbc::MapField<int, float>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForFloat(21), 1002);
     internal class MapInt32FloatMapConverter : EventMapConverter<int, float> {
-      public override ByteString GetKeyValue(int key, float value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, float value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteFloat(value);
+          dataStream.WriteFloat(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, float> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, float> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapInt32Float = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, float>(realKeymapInt32Float, default(float));
-        }
-        else {
-          var realValuemapInt32Float = dataStream.ReadFloat();
-          return new KeyValuePair<int, float>(realKeymapInt32Float, realValuemapInt32Float);
-        }
+        var realValuemapInt32Float = dataStream.ReadFloat();
+        return new KeyValuePair<int, float>(realKeymapInt32Float, realValuemapInt32Float);
       }
     }
     private static readonly EventMapConverter<int, float> mapInt32FloatMapConverter = new MapInt32FloatMapConverter();
@@ -2347,25 +2358,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<int, double>.Codec _map_mapInt32Double_codec
         = new pbc::MapField<int, double>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForDouble(17), 1010);
     internal class MapInt32DoubleMapConverter : EventMapConverter<int, double> {
-      public override ByteString GetKeyValue(int key, double value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, double value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteDouble(value);
+          dataStream.WriteDouble(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, double> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, double> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapInt32Double = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, double>(realKeymapInt32Double, default(double));
-        }
-        else {
-          var realValuemapInt32Double = dataStream.ReadDouble();
-          return new KeyValuePair<int, double>(realKeymapInt32Double, realValuemapInt32Double);
-        }
+        var realValuemapInt32Double = dataStream.ReadDouble();
+        return new KeyValuePair<int, double>(realKeymapInt32Double, realValuemapInt32Double);
       }
     }
     private static readonly EventMapConverter<int, double> mapInt32DoubleMapConverter = new MapInt32DoubleMapConverter();
@@ -2380,25 +2392,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<bool, bool>.Codec _map_mapBoolBool_codec
         = new pbc::MapField<bool, bool>.Codec(pb::FieldCodec.ForBool(8), pb::FieldCodec.ForBool(16), 1018);
     internal class MapBoolBoolMapConverter : EventMapConverter<bool, bool> {
-      public override ByteString GetKeyValue(bool key, bool value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(bool key) {
+        return new zpr.EventSource.MapKey { BoolData = key };
+      }
+      public override bool GetKey(zpr.EventSource.MapKey key) {
+        return key.BoolData;
+      }
+      public override ByteString GetKeyValue(bool key, bool value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteBool(key);
-          if(!skipValue) dataStream.WriteBool(value);
+          dataStream.WriteBool(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<bool, bool> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<bool, bool> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapBoolBool = dataStream.ReadBool();
-        if (skipValue) {
-          return new KeyValuePair<bool, bool>(realKeymapBoolBool, default(bool));
-        }
-        else {
-          var realValuemapBoolBool = dataStream.ReadBool();
-          return new KeyValuePair<bool, bool>(realKeymapBoolBool, realValuemapBoolBool);
-        }
+        var realValuemapBoolBool = dataStream.ReadBool();
+        return new KeyValuePair<bool, bool>(realKeymapBoolBool, realValuemapBoolBool);
       }
     }
     private static readonly EventMapConverter<bool, bool> mapBoolBoolMapConverter = new MapBoolBoolMapConverter();
@@ -2413,25 +2426,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<string, string>.Codec _map_mapStringString_codec
         = new pbc::MapField<string, string>.Codec(pb::FieldCodec.ForString(10), pb::FieldCodec.ForString(18), 1026);
     internal class MapStringStringMapConverter : EventMapConverter<string, string> {
-      public override ByteString GetKeyValue(string key, string value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(string key) {
+        return new zpr.EventSource.MapKey { StringData = key };
+      }
+      public override string GetKey(zpr.EventSource.MapKey key) {
+        return key.StringData;
+      }
+      public override ByteString GetKeyValue(string key, string value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteString(key);
-          if(!skipValue) dataStream.WriteString(value);
+          dataStream.WriteString(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<string, string> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<string, string> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapStringString = dataStream.ReadString();
-        if (skipValue) {
-          return new KeyValuePair<string, string>(realKeymapStringString, default(string));
-        }
-        else {
-          var realValuemapStringString = dataStream.ReadString();
-          return new KeyValuePair<string, string>(realKeymapStringString, realValuemapStringString);
-        }
+        var realValuemapStringString = dataStream.ReadString();
+        return new KeyValuePair<string, string>(realKeymapStringString, realValuemapStringString);
       }
     }
     private static readonly EventMapConverter<string, string> mapStringStringMapConverter = new MapStringStringMapConverter();
@@ -2446,25 +2460,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<int, pb::ByteString>.Codec _map_mapInt32Bytes_codec
         = new pbc::MapField<int, pb::ByteString>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForBytes(18), 1034);
     internal class MapInt32BytesMapConverter : EventMapConverter<int, pb::ByteString> {
-      public override ByteString GetKeyValue(int key, pb::ByteString value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, pb::ByteString value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteBytes(value);
+          dataStream.WriteBytes(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, pb::ByteString> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, pb::ByteString> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapInt32Bytes = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, pb::ByteString>(realKeymapInt32Bytes, default(pb::ByteString));
-        }
-        else {
-          var realValuemapInt32Bytes = dataStream.ReadBytes();
-          return new KeyValuePair<int, pb::ByteString>(realKeymapInt32Bytes, realValuemapInt32Bytes);
-        }
+        var realValuemapInt32Bytes = dataStream.ReadBytes();
+        return new KeyValuePair<int, pb::ByteString>(realKeymapInt32Bytes, realValuemapInt32Bytes);
       }
     }
     private static readonly EventMapConverter<int, pb::ByteString> mapInt32BytesMapConverter = new MapInt32BytesMapConverter();
@@ -2479,25 +2494,26 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<int, global::Google.Protobuf.TestProtos.MapEnum>.Codec _map_mapInt32Enum_codec
         = new pbc::MapField<int, global::Google.Protobuf.TestProtos.MapEnum>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForEnum(16, x => (int) x, x => (global::Google.Protobuf.TestProtos.MapEnum) x), 1042);
     internal class MapInt32EnumMapConverter : EventMapConverter<int, global::Google.Protobuf.TestProtos.MapEnum> {
-      public override ByteString GetKeyValue(int key, global::Google.Protobuf.TestProtos.MapEnum value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, global::Google.Protobuf.TestProtos.MapEnum value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteEnum((int) value);
+          dataStream.WriteEnum((int) value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, global::Google.Protobuf.TestProtos.MapEnum> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, global::Google.Protobuf.TestProtos.MapEnum> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapInt32Enum = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, global::Google.Protobuf.TestProtos.MapEnum>(realKeymapInt32Enum, default(global::Google.Protobuf.TestProtos.MapEnum));
-        }
-        else {
-          var realValuemapInt32Enum = (global::Google.Protobuf.TestProtos.MapEnum) dataStream.ReadEnum();
-          return new KeyValuePair<int, global::Google.Protobuf.TestProtos.MapEnum>(realKeymapInt32Enum, realValuemapInt32Enum);
-        }
+        var realValuemapInt32Enum = (global::Google.Protobuf.TestProtos.MapEnum) dataStream.ReadEnum();
+        return new KeyValuePair<int, global::Google.Protobuf.TestProtos.MapEnum>(realKeymapInt32Enum, realValuemapInt32Enum);
       }
     }
     private static readonly EventMapConverter<int, global::Google.Protobuf.TestProtos.MapEnum> mapInt32EnumMapConverter = new MapInt32EnumMapConverter();
@@ -2512,26 +2528,27 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<int, global::Google.Protobuf.TestProtos.ForeignMessage>.Codec _map_mapInt32ForeignMessage_codec
         = new pbc::MapField<int, global::Google.Protobuf.TestProtos.ForeignMessage>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForMessage(18, global::Google.Protobuf.TestProtos.ForeignMessage.Parser), 1050);
     internal class MapInt32ForeignMessageMapConverter : EventMapConverter<int, global::Google.Protobuf.TestProtos.ForeignMessage> {
-      public override ByteString GetKeyValue(int key, global::Google.Protobuf.TestProtos.ForeignMessage value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, global::Google.Protobuf.TestProtos.ForeignMessage value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteMessage(value);
+          dataStream.WriteMessage(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, global::Google.Protobuf.TestProtos.ForeignMessage> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, global::Google.Protobuf.TestProtos.ForeignMessage> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapInt32ForeignMessage = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, global::Google.Protobuf.TestProtos.ForeignMessage>(realKeymapInt32ForeignMessage, default(global::Google.Protobuf.TestProtos.ForeignMessage));
-        }
-        else {
-          var realValuemapInt32ForeignMessage = new global::Google.Protobuf.TestProtos.ForeignMessage();
-          dataStream.ReadMessage(realValuemapInt32ForeignMessage);;
-          return new KeyValuePair<int, global::Google.Protobuf.TestProtos.ForeignMessage>(realKeymapInt32ForeignMessage, realValuemapInt32ForeignMessage);
-        }
+        var realValuemapInt32ForeignMessage = new global::Google.Protobuf.TestProtos.ForeignMessage();
+        dataStream.ReadMessage(realValuemapInt32ForeignMessage);;
+        return new KeyValuePair<int, global::Google.Protobuf.TestProtos.ForeignMessage>(realKeymapInt32ForeignMessage, realValuemapInt32ForeignMessage);
       }
     }
     private static readonly EventMapConverter<int, global::Google.Protobuf.TestProtos.ForeignMessage> mapInt32ForeignMessageMapConverter = new MapInt32ForeignMessageMapConverter();
@@ -2546,26 +2563,27 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<int, global::Google.Protobuf.TestProtos.ForeignMessageNoEvents>.Codec _map_mapInt32ForeignNoEventsMessage_codec
         = new pbc::MapField<int, global::Google.Protobuf.TestProtos.ForeignMessageNoEvents>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForMessage(18, global::Google.Protobuf.TestProtos.ForeignMessageNoEvents.Parser), 1058);
     internal class MapInt32ForeignNoEventsMessageMapConverter : EventMapConverter<int, global::Google.Protobuf.TestProtos.ForeignMessageNoEvents> {
-      public override ByteString GetKeyValue(int key, global::Google.Protobuf.TestProtos.ForeignMessageNoEvents value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, global::Google.Protobuf.TestProtos.ForeignMessageNoEvents value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteMessage(value);
+          dataStream.WriteMessage(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, global::Google.Protobuf.TestProtos.ForeignMessageNoEvents> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, global::Google.Protobuf.TestProtos.ForeignMessageNoEvents> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapInt32ForeignNoEventsMessage = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, global::Google.Protobuf.TestProtos.ForeignMessageNoEvents>(realKeymapInt32ForeignNoEventsMessage, default(global::Google.Protobuf.TestProtos.ForeignMessageNoEvents));
-        }
-        else {
-          var realValuemapInt32ForeignNoEventsMessage = new global::Google.Protobuf.TestProtos.ForeignMessageNoEvents();
-          dataStream.ReadMessage(realValuemapInt32ForeignNoEventsMessage);;
-          return new KeyValuePair<int, global::Google.Protobuf.TestProtos.ForeignMessageNoEvents>(realKeymapInt32ForeignNoEventsMessage, realValuemapInt32ForeignNoEventsMessage);
-        }
+        var realValuemapInt32ForeignNoEventsMessage = new global::Google.Protobuf.TestProtos.ForeignMessageNoEvents();
+        dataStream.ReadMessage(realValuemapInt32ForeignNoEventsMessage);;
+        return new KeyValuePair<int, global::Google.Protobuf.TestProtos.ForeignMessageNoEvents>(realKeymapInt32ForeignNoEventsMessage, realValuemapInt32ForeignNoEventsMessage);
       }
     }
     private static readonly EventMapConverter<int, global::Google.Protobuf.TestProtos.ForeignMessageNoEvents> mapInt32ForeignNoEventsMessageMapConverter = new MapInt32ForeignNoEventsMessageMapConverter();
@@ -2580,26 +2598,27 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<int, global::Google.Protobuf.TestProtos.TestAllTypes>.Codec _map_mapInt32TestAllTypesMessage_codec
         = new pbc::MapField<int, global::Google.Protobuf.TestProtos.TestAllTypes>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForMessage(18, global::Google.Protobuf.TestProtos.TestAllTypes.Parser), 1066);
     internal class MapInt32TestAllTypesMessageMapConverter : EventMapConverter<int, global::Google.Protobuf.TestProtos.TestAllTypes> {
-      public override ByteString GetKeyValue(int key, global::Google.Protobuf.TestProtos.TestAllTypes value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, global::Google.Protobuf.TestProtos.TestAllTypes value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteMessage(value);
+          dataStream.WriteMessage(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, global::Google.Protobuf.TestProtos.TestAllTypes> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, global::Google.Protobuf.TestProtos.TestAllTypes> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapInt32TestAllTypesMessage = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, global::Google.Protobuf.TestProtos.TestAllTypes>(realKeymapInt32TestAllTypesMessage, default(global::Google.Protobuf.TestProtos.TestAllTypes));
-        }
-        else {
-          var realValuemapInt32TestAllTypesMessage = new global::Google.Protobuf.TestProtos.TestAllTypes();
-          dataStream.ReadMessage(realValuemapInt32TestAllTypesMessage);;
-          return new KeyValuePair<int, global::Google.Protobuf.TestProtos.TestAllTypes>(realKeymapInt32TestAllTypesMessage, realValuemapInt32TestAllTypesMessage);
-        }
+        var realValuemapInt32TestAllTypesMessage = new global::Google.Protobuf.TestProtos.TestAllTypes();
+        dataStream.ReadMessage(realValuemapInt32TestAllTypesMessage);;
+        return new KeyValuePair<int, global::Google.Protobuf.TestProtos.TestAllTypes>(realKeymapInt32TestAllTypesMessage, realValuemapInt32TestAllTypesMessage);
       }
     }
     private static readonly EventMapConverter<int, global::Google.Protobuf.TestProtos.TestAllTypes> mapInt32TestAllTypesMessageMapConverter = new MapInt32TestAllTypesMessageMapConverter();
@@ -2614,26 +2633,27 @@ namespace Google.Protobuf.TestProtos {
     private static readonly pbc::MapField<int, global::Google.Protobuf.TestProtos.TestAllTypesNoEvents>.Codec _map_mapInt32TestAllTypesNoEventsMessage_codec
         = new pbc::MapField<int, global::Google.Protobuf.TestProtos.TestAllTypesNoEvents>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForMessage(18, global::Google.Protobuf.TestProtos.TestAllTypesNoEvents.Parser), 1074);
     internal class MapInt32TestAllTypesNoEventsMessageMapConverter : EventMapConverter<int, global::Google.Protobuf.TestProtos.TestAllTypesNoEvents> {
-      public override ByteString GetKeyValue(int key, global::Google.Protobuf.TestProtos.TestAllTypesNoEvents value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, global::Google.Protobuf.TestProtos.TestAllTypesNoEvents value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteMessage(value);
+          dataStream.WriteMessage(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, global::Google.Protobuf.TestProtos.TestAllTypesNoEvents> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, global::Google.Protobuf.TestProtos.TestAllTypesNoEvents> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapInt32TestAllTypesNoEventsMessage = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, global::Google.Protobuf.TestProtos.TestAllTypesNoEvents>(realKeymapInt32TestAllTypesNoEventsMessage, default(global::Google.Protobuf.TestProtos.TestAllTypesNoEvents));
-        }
-        else {
-          var realValuemapInt32TestAllTypesNoEventsMessage = new global::Google.Protobuf.TestProtos.TestAllTypesNoEvents();
-          dataStream.ReadMessage(realValuemapInt32TestAllTypesNoEventsMessage);;
-          return new KeyValuePair<int, global::Google.Protobuf.TestProtos.TestAllTypesNoEvents>(realKeymapInt32TestAllTypesNoEventsMessage, realValuemapInt32TestAllTypesNoEventsMessage);
-        }
+        var realValuemapInt32TestAllTypesNoEventsMessage = new global::Google.Protobuf.TestProtos.TestAllTypesNoEvents();
+        dataStream.ReadMessage(realValuemapInt32TestAllTypesNoEventsMessage);;
+        return new KeyValuePair<int, global::Google.Protobuf.TestProtos.TestAllTypesNoEvents>(realKeymapInt32TestAllTypesNoEventsMessage, realValuemapInt32TestAllTypesNoEventsMessage);
       }
     }
     private static readonly EventMapConverter<int, global::Google.Protobuf.TestProtos.TestAllTypesNoEvents> mapInt32TestAllTypesNoEventsMessageMapConverter = new MapInt32TestAllTypesNoEventsMessageMapConverter();

--- a/runtime/src/Zynga.Protobuf.Runtime.Tests/UpgradeTest.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime.Tests/UpgradeTest.cs
@@ -604,25 +604,26 @@ namespace Com.Zynga.Runtime.Protobuf {
     private static readonly pbc::MapField<int, string>.Codec _map_mapA_codec
         = new pbc::MapField<int, string>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForString(18), 50);
     internal class MapAMapConverter : EventMapConverter<int, string> {
-      public override ByteString GetKeyValue(int key, string value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, string value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteString(value);
+          dataStream.WriteString(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, string> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, string> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapA = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, string>(realKeymapA, default(string));
-        }
-        else {
-          var realValuemapA = dataStream.ReadString();
-          return new KeyValuePair<int, string>(realKeymapA, realValuemapA);
-        }
+        var realValuemapA = dataStream.ReadString();
+        return new KeyValuePair<int, string>(realKeymapA, realValuemapA);
       }
     }
     private static readonly EventMapConverter<int, string> mapAMapConverter = new MapAMapConverter();
@@ -1049,25 +1050,26 @@ namespace Com.Zynga.Runtime.Protobuf {
     private static readonly pbc::MapField<int, string>.Codec _map_mapB_codec
         = new pbc::MapField<int, string>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForString(18), 50);
     internal class MapBMapConverter : EventMapConverter<int, string> {
-      public override ByteString GetKeyValue(int key, string value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, string value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteString(value);
+          dataStream.WriteString(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, string> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, string> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapB = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, string>(realKeymapB, default(string));
-        }
-        else {
-          var realValuemapB = dataStream.ReadString();
-          return new KeyValuePair<int, string>(realKeymapB, realValuemapB);
-        }
+        var realValuemapB = dataStream.ReadString();
+        return new KeyValuePair<int, string>(realKeymapB, realValuemapB);
       }
     }
     private static readonly EventMapConverter<int, string> mapBMapConverter = new MapBMapConverter();
@@ -1498,25 +1500,26 @@ namespace Com.Zynga.Runtime.Protobuf {
     private static readonly pbc::MapField<int, string>.Codec _map_mapB_codec
         = new pbc::MapField<int, string>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForString(18), 50);
     internal class MapBMapConverter : EventMapConverter<int, string> {
-      public override ByteString GetKeyValue(int key, string value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, string value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteString(value);
+          dataStream.WriteString(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, string> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, string> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapB = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, string>(realKeymapB, default(string));
-        }
-        else {
-          var realValuemapB = dataStream.ReadString();
-          return new KeyValuePair<int, string>(realKeymapB, realValuemapB);
-        }
+        var realValuemapB = dataStream.ReadString();
+        return new KeyValuePair<int, string>(realKeymapB, realValuemapB);
       }
     }
     private static readonly EventMapConverter<int, string> mapBMapConverter = new MapBMapConverter();
@@ -2002,25 +2005,26 @@ namespace Com.Zynga.Runtime.Protobuf {
     private static readonly pbc::MapField<int, string>.Codec _map_mapB_codec
         = new pbc::MapField<int, string>.Codec(pb::FieldCodec.ForInt32(8), pb::FieldCodec.ForString(18), 50);
     internal class MapBMapConverter : EventMapConverter<int, string> {
-      public override ByteString GetKeyValue(int key, string value, bool skipValue = false) {
+      public override zpr.EventSource.MapKey GetMapKey(int key) {
+        return new zpr.EventSource.MapKey { I32 = key };
+      }
+      public override int GetKey(zpr.EventSource.MapKey key) {
+        return key.I32;
+      }
+      public override ByteString GetKeyValue(int key, string value) {
         using (var memStream = new MemoryStream()) {
           var dataStream = new CodedOutputStream(memStream);
           dataStream.WriteInt32(key);
-          if(!skipValue) dataStream.WriteString(value);
+          dataStream.WriteString(value);
           dataStream.Flush();
           return ByteString.CopyFrom(memStream.ToArray());
         }
       }
-      public override KeyValuePair<int, string> GetItem(ByteString data, bool skipValue = false) {
+      public override KeyValuePair<int, string> GetItem(ByteString data) {
         var dataStream = data.CreateCodedInput();
         var realKeymapB = dataStream.ReadInt32();
-        if (skipValue) {
-          return new KeyValuePair<int, string>(realKeymapB, default(string));
-        }
-        else {
-          var realValuemapB = dataStream.ReadString();
-          return new KeyValuePair<int, string>(realKeymapB, realValuemapB);
-        }
+        var realValuemapB = dataStream.ReadString();
+        return new KeyValuePair<int, string>(realKeymapB, realValuemapB);
       }
     }
     private static readonly EventMapConverter<int, string> mapBMapConverter = new MapBMapConverter();

--- a/runtime/src/Zynga.Protobuf.Runtime/EventMapConverter.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventMapConverter.cs
@@ -1,16 +1,21 @@
 ﻿using System.Collections.Generic;
 using Google.Protobuf;
+using Zynga.Protobuf.Runtime.EventSource;
 
 namespace Zynga.Protobuf.Runtime {
 	public abstract class EventMapConverter<TKey, TValue> {
+		public abstract MapKey GetMapKey(TKey key);
+
+		public abstract TKey GetKey(MapKey key);
+
 		/// <summary>
 		/// Returns EventContent for the specified data
 		/// </summary>
-		public abstract ByteString GetKeyValue(TKey key, TValue value, bool skipValue = false);
+		public abstract ByteString GetKeyValue(TKey key, TValue value);
 
 		/// <summary>
 		/// Returns the data for the specified EventContent
 		/// </summary>
-		public abstract KeyValuePair<TKey, TValue> GetItem(ByteString data, bool skipValue = false);
+		public abstract KeyValuePair<TKey, TValue> GetItem(ByteString data);
 	}
 }

--- a/runtime/src/Zynga.Protobuf.Runtime/EventMapField.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventMapField.cs
@@ -301,7 +301,7 @@ namespace Zynga.Protobuf.Runtime {
 			if (!_context.EventsEnabled) return;
 			var mapEvent = new MapEvent {
 				MapAction = MapAction.RemoveMap,
-				KeyValue = _converter.GetKeyValue(key, default(TValue), true)
+				Key = _converter.GetMapKey(key)
 			};
 			_context.AddMapEvent(_fieldNumber, mapEvent);
 		}
@@ -335,8 +335,8 @@ namespace Zynga.Protobuf.Runtime {
 					InternalAdd(addPair.Key, addPair.Value);
 					return true;
 				case MapAction.RemoveMap:
-					var removePair = _converter.GetItem(e.KeyValue, true);
-					InternalRemove(removePair.Key);
+					var removeKey = _converter.GetKey(e.Key);
+					InternalRemove(removeKey);
 					return true;
 				case MapAction.ReplaceMap:
 					var replacePair = _converter.GetItem(e.KeyValue);
@@ -347,8 +347,8 @@ namespace Zynga.Protobuf.Runtime {
 					MarkDirty();
 					return true;
 				case MapAction.UpdateMap:
-					var updatePair = _converter.GetItem(e.KeyValue, true);
-					var registry = _internal[updatePair.Key] as IEventRegistry;
+					var updateKey = _converter.GetKey(e.Key);
+					var registry = _internal[updateKey] as IEventRegistry;
 					registry?.ApplyEvent(e.EventData, 0);
 					MarkDirty();
 					return true;
@@ -411,8 +411,8 @@ namespace Zynga.Protobuf.Runtime {
 
 		private void SetParent(TKey key, TValue value) {
 			var registry = value as IEventRegistry;
-			var keyBytes = _converter.GetKeyValue(key, value, true);
-			registry?.SetParent(new MapEventContext(_context, keyBytes, _fieldNumber), EventPath.Empty);
+			var mapKey = _converter.GetMapKey(key);
+			registry?.SetParent(new MapEventContext(_context, mapKey, _fieldNumber), EventPath.Empty);
 		}
 
 		private class DictionaryEnumerator : IDictionaryEnumerator {

--- a/runtime/src/Zynga.Protobuf.Runtime/Generated/EventSource.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/Generated/EventSource.cs
@@ -34,43 +34,52 @@ namespace Zynga.Protobuf.Runtime.EventSource {
             "EhQKBWluZGV4GAIgASgFUgVpbmRleBJCCgdjb250ZW50GAMgASgLMiguY29t",
             "Lnp5bmdhLnJ1bnRpbWUucHJvdG9idWYuRXZlbnRDb250ZW50Ugdjb250ZW50",
             "EkQKCmV2ZW50X2RhdGEYBCABKAsyJS5jb20uenluZ2EucnVudGltZS5wcm90",
-            "b2J1Zi5FdmVudERhdGFSCWV2ZW50RGF0YSKzAQoITWFwRXZlbnQSRAoKbWFw",
+            "b2J1Zi5FdmVudERhdGFSCWV2ZW50RGF0YSLpAQoITWFwRXZlbnQSRAoKbWFw",
             "X2FjdGlvbhgBIAEoDjIlLmNvbS56eW5nYS5ydW50aW1lLnByb3RvYnVmLk1h",
-            "cEFjdGlvblIJbWFwQWN0aW9uEhsKCWtleV92YWx1ZRgCIAEoDFIIa2V5VmFs",
-            "dWUSRAoKZXZlbnRfZGF0YRgDIAEoCzIlLmNvbS56eW5nYS5ydW50aW1lLnBy",
-            "b3RvYnVmLkV2ZW50RGF0YVIJZXZlbnREYXRhIlAKD0V2ZW50U291cmNlUm9v",
-            "dBI9CgZldmVudHMYASADKAsyJS5jb20uenluZ2EucnVudGltZS5wcm90b2J1",
-            "Zi5FdmVudERhdGFSBmV2ZW50cyL0AQoJRXZlbnREYXRhEhIKBHBhdGgYASAD",
-            "KAVSBHBhdGgSPAoDc2V0GAIgASgLMiguY29tLnp5bmdhLnJ1bnRpbWUucHJv",
-            "dG9idWYuRXZlbnRDb250ZW50SABSA3NldBJDCgltYXBfZXZlbnQYAyABKAsy",
-            "JC5jb20uenluZ2EucnVudGltZS5wcm90b2J1Zi5NYXBFdmVudEgAUghtYXBF",
-            "dmVudBJGCgpsaXN0X2V2ZW50GAQgASgLMiUuY29tLnp5bmdhLnJ1bnRpbWUu",
-            "cHJvdG9idWYuTGlzdEV2ZW50SABSCWxpc3RFdmVudEIICgZhY3Rpb24i/wIK",
-            "DEV2ZW50Q29udGVudBITCgR1XzMyGAEgASgNSABSA3UzMhITCgRpXzMyGAIg",
-            "ASgFSABSA2kzMhITCgRmXzY0GAMgASgGSABSA2Y2NBITCgRmXzMyGAQgASgH",
-            "SABSA2YzMhIWCgZzX2ZfNjQYBSABKBBIAFIEc0Y2NBIWCgZzX2ZfMzIYBiAB",
-            "KA9IAFIEc0YzMhITCgRyXzY0GAcgASgBSABSA3I2NBITCgRyXzMyGAggASgC",
-            "SABSA3IzMhIdCglib29sX2RhdGEYCSABKAhIAFIIYm9vbERhdGESIQoLc3Ry",
-            "aW5nX2RhdGEYCiABKAlIAFIKc3RyaW5nRGF0YRIdCglieXRlX2RhdGEYCyAB",
-            "KAxIAFIIYnl0ZURhdGESEwoEaV82NBgMIAEoA0gAUgNpNjQSEwoEdV82NBgN",
-            "IAEoBEgAUgN1NjQSFgoGc19pXzMyGA4gASgRSABSBHNJMzISFgoGc19pXzY0",
-            "GA8gASgSSABSBHNJNjRCBgoEZGF0YSqVAQoKTGlzdEFjdGlvbhIQCgxVTktO",
-            "T1dOX0xJU1QQABIMCghBRERfTElTVBABEg8KC1JFTU9WRV9MSVNUEAISEgoO",
-            "UkVNT1ZFX0FUX0xJU1QQAxIQCgxSRVBMQUNFX0xJU1QQBBIPCgtJTlNFUlRf",
-            "TElTVBAFEg4KCkNMRUFSX0xJU1QQBhIPCgtVUERBVEVfTElTVBAHKmkKCU1h",
-            "cEFjdGlvbhIPCgtVTktOT1dOX01BUBAAEgsKB0FERF9NQVAQARIOCgpSRU1P",
-            "VkVfTUFQEAISDwoLUkVQTEFDRV9NQVAQAxINCglDTEVBUl9NQVAQBBIOCgpV",
-            "UERBVEVfTUFQEAVCRgoSY29tLnp5bmdhLnByb3RvYnVmQgtFdmVudFNvdXJj",
-            "ZaoCIlp5bmdhLlByb3RvYnVmLlJ1bnRpbWUuRXZlbnRTb3VyY2ViBnByb3Rv",
-            "Mw=="));
+            "cEFjdGlvblIJbWFwQWN0aW9uEjQKA2tleRgCIAEoCzIiLmNvbS56eW5nYS5y",
+            "dW50aW1lLnByb3RvYnVmLk1hcEtleVIDa2V5EhsKCWtleV92YWx1ZRgDIAEo",
+            "DFIIa2V5VmFsdWUSRAoKZXZlbnRfZGF0YRgEIAEoCzIlLmNvbS56eW5nYS5y",
+            "dW50aW1lLnByb3RvYnVmLkV2ZW50RGF0YVIJZXZlbnREYXRhIlAKD0V2ZW50",
+            "U291cmNlUm9vdBI9CgZldmVudHMYASADKAsyJS5jb20uenluZ2EucnVudGlt",
+            "ZS5wcm90b2J1Zi5FdmVudERhdGFSBmV2ZW50cyL0AQoJRXZlbnREYXRhEhIK",
+            "BHBhdGgYASADKAVSBHBhdGgSPAoDc2V0GAIgASgLMiguY29tLnp5bmdhLnJ1",
+            "bnRpbWUucHJvdG9idWYuRXZlbnRDb250ZW50SABSA3NldBJDCgltYXBfZXZl",
+            "bnQYAyABKAsyJC5jb20uenluZ2EucnVudGltZS5wcm90b2J1Zi5NYXBFdmVu",
+            "dEgAUghtYXBFdmVudBJGCgpsaXN0X2V2ZW50GAQgASgLMiUuY29tLnp5bmdh",
+            "LnJ1bnRpbWUucHJvdG9idWYuTGlzdEV2ZW50SABSCWxpc3RFdmVudEIICgZh",
+            "Y3Rpb24i/wIKDEV2ZW50Q29udGVudBITCgR1XzMyGAEgASgNSABSA3UzMhIT",
+            "CgRpXzMyGAIgASgFSABSA2kzMhITCgRmXzY0GAMgASgGSABSA2Y2NBITCgRm",
+            "XzMyGAQgASgHSABSA2YzMhIWCgZzX2ZfNjQYBSABKBBIAFIEc0Y2NBIWCgZz",
+            "X2ZfMzIYBiABKA9IAFIEc0YzMhITCgRyXzY0GAcgASgBSABSA3I2NBITCgRy",
+            "XzMyGAggASgCSABSA3IzMhIdCglib29sX2RhdGEYCSABKAhIAFIIYm9vbERh",
+            "dGESIQoLc3RyaW5nX2RhdGEYCiABKAlIAFIKc3RyaW5nRGF0YRIdCglieXRl",
+            "X2RhdGEYCyABKAxIAFIIYnl0ZURhdGESEwoEaV82NBgMIAEoA0gAUgNpNjQS",
+            "EwoEdV82NBgNIAEoBEgAUgN1NjQSFgoGc19pXzMyGA4gASgRSABSBHNJMzIS",
+            "FgoGc19pXzY0GA8gASgSSABSBHNJNjRCBgoEZGF0YSKwAgoGTWFwS2V5EhMK",
+            "BHVfMzIYASABKA1IAFIDdTMyEhMKBGlfMzIYAiABKAVIAFIDaTMyEhMKBGZf",
+            "NjQYAyABKAZIAFIDZjY0EhMKBGZfMzIYBCABKAdIAFIDZjMyEhYKBnNfZl82",
+            "NBgFIAEoEEgAUgRzRjY0EhYKBnNfZl8zMhgGIAEoD0gAUgRzRjMyEh0KCWJv",
+            "b2xfZGF0YRgJIAEoCEgAUghib29sRGF0YRIhCgtzdHJpbmdfZGF0YRgKIAEo",
+            "CUgAUgpzdHJpbmdEYXRhEhMKBGlfNjQYDCABKANIAFIDaTY0EhMKBHVfNjQY",
+            "DSABKARIAFIDdTY0EhYKBnNfaV8zMhgOIAEoEUgAUgRzSTMyEhYKBnNfaV82",
+            "NBgPIAEoEkgAUgRzSTY0QgYKBGRhdGEqlQEKCkxpc3RBY3Rpb24SEAoMVU5L",
+            "Tk9XTl9MSVNUEAASDAoIQUREX0xJU1QQARIPCgtSRU1PVkVfTElTVBACEhIK",
+            "DlJFTU9WRV9BVF9MSVNUEAMSEAoMUkVQTEFDRV9MSVNUEAQSDwoLSU5TRVJU",
+            "X0xJU1QQBRIOCgpDTEVBUl9MSVNUEAYSDwoLVVBEQVRFX0xJU1QQByppCglN",
+            "YXBBY3Rpb24SDwoLVU5LTk9XTl9NQVAQABILCgdBRERfTUFQEAESDgoKUkVN",
+            "T1ZFX01BUBACEg8KC1JFUExBQ0VfTUFQEAMSDQoJQ0xFQVJfTUFQEAQSDgoK",
+            "VVBEQVRFX01BUBAFQkYKEmNvbS56eW5nYS5wcm90b2J1ZkILRXZlbnRTb3Vy",
+            "Y2WqAiJaeW5nYS5Qcm90b2J1Zi5SdW50aW1lLkV2ZW50U291cmNlYgZwcm90",
+            "bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Zynga.Protobuf.Runtime.EventSource.ListAction), typeof(global::Zynga.Protobuf.Runtime.EventSource.MapAction), }, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Zynga.Protobuf.Runtime.EventSource.ListEvent), global::Zynga.Protobuf.Runtime.EventSource.ListEvent.Parser, new[]{ "ListAction", "Index", "Content", "EventData" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Zynga.Protobuf.Runtime.EventSource.MapEvent), global::Zynga.Protobuf.Runtime.EventSource.MapEvent.Parser, new[]{ "MapAction", "KeyValue", "EventData" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Zynga.Protobuf.Runtime.EventSource.MapEvent), global::Zynga.Protobuf.Runtime.EventSource.MapEvent.Parser, new[]{ "MapAction", "Key", "KeyValue", "EventData" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Zynga.Protobuf.Runtime.EventSource.EventSourceRoot), global::Zynga.Protobuf.Runtime.EventSource.EventSourceRoot.Parser, new[]{ "Events" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Zynga.Protobuf.Runtime.EventSource.EventData), global::Zynga.Protobuf.Runtime.EventSource.EventData.Parser, new[]{ "Path", "Set", "MapEvent", "ListEvent" }, new[]{ "Action" }, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Zynga.Protobuf.Runtime.EventSource.EventContent), global::Zynga.Protobuf.Runtime.EventSource.EventContent.Parser, new[]{ "U32", "I32", "F64", "F32", "SF64", "SF32", "R64", "R32", "BoolData", "StringData", "ByteData", "I64", "U64", "SI32", "SI64" }, new[]{ "Data" }, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Zynga.Protobuf.Runtime.EventSource.EventContent), global::Zynga.Protobuf.Runtime.EventSource.EventContent.Parser, new[]{ "U32", "I32", "F64", "F32", "SF64", "SF32", "R64", "R32", "BoolData", "StringData", "ByteData", "I64", "U64", "SI32", "SI64" }, new[]{ "Data" }, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Zynga.Protobuf.Runtime.EventSource.MapKey), global::Zynga.Protobuf.Runtime.EventSource.MapKey.Parser, new[]{ "U32", "I32", "F64", "F32", "SF64", "SF32", "BoolData", "StringData", "I64", "U64", "SI32", "SI64" }, new[]{ "Data" }, null, null)
           }));
     }
     #endregion
@@ -343,6 +352,7 @@ namespace Zynga.Protobuf.Runtime.EventSource {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public MapEvent(MapEvent other) : this() {
       mapAction_ = other.mapAction_;
+      key_ = other.key_ != null ? other.Key.Clone() : null;
       keyValue_ = other.keyValue_;
       eventData_ = other.eventData_ != null ? other.EventData.Clone() : null;
     }
@@ -365,8 +375,19 @@ namespace Zynga.Protobuf.Runtime.EventSource {
       }
     }
 
+    /// <summary>Field number for the "key" field.</summary>
+    public const int KeyFieldNumber = 2;
+    private global::Zynga.Protobuf.Runtime.EventSource.MapKey key_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public global::Zynga.Protobuf.Runtime.EventSource.MapKey Key {
+      get { return key_; }
+      set {
+        key_ = value;
+      }
+    }
+
     /// <summary>Field number for the "key_value" field.</summary>
-    public const int KeyValueFieldNumber = 2;
+    public const int KeyValueFieldNumber = 3;
     private pb::ByteString keyValue_ = pb::ByteString.Empty;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public pb::ByteString KeyValue {
@@ -377,7 +398,7 @@ namespace Zynga.Protobuf.Runtime.EventSource {
     }
 
     /// <summary>Field number for the "event_data" field.</summary>
-    public const int EventDataFieldNumber = 3;
+    public const int EventDataFieldNumber = 4;
     private global::Zynga.Protobuf.Runtime.EventSource.EventData eventData_;
     /// <summary>
     /// only used by update action
@@ -404,6 +425,7 @@ namespace Zynga.Protobuf.Runtime.EventSource {
         return true;
       }
       if (MapAction != other.MapAction) return false;
+      if (!object.Equals(Key, other.Key)) return false;
       if (KeyValue != other.KeyValue) return false;
       if (!object.Equals(EventData, other.EventData)) return false;
       return true;
@@ -413,6 +435,7 @@ namespace Zynga.Protobuf.Runtime.EventSource {
     public override int GetHashCode() {
       int hash = 1;
       if (MapAction != 0) hash ^= MapAction.GetHashCode();
+      if (key_ != null) hash ^= Key.GetHashCode();
       if (KeyValue.Length != 0) hash ^= KeyValue.GetHashCode();
       if (eventData_ != null) hash ^= EventData.GetHashCode();
       return hash;
@@ -429,12 +452,16 @@ namespace Zynga.Protobuf.Runtime.EventSource {
         output.WriteRawTag(8);
         output.WriteEnum((int) MapAction);
       }
-      if (KeyValue.Length != 0) {
+      if (key_ != null) {
         output.WriteRawTag(18);
+        output.WriteMessage(Key);
+      }
+      if (KeyValue.Length != 0) {
+        output.WriteRawTag(26);
         output.WriteBytes(KeyValue);
       }
       if (eventData_ != null) {
-        output.WriteRawTag(26);
+        output.WriteRawTag(34);
         output.WriteMessage(EventData);
       }
     }
@@ -444,6 +471,9 @@ namespace Zynga.Protobuf.Runtime.EventSource {
       int size = 0;
       if (MapAction != 0) {
         size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) MapAction);
+      }
+      if (key_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Key);
       }
       if (KeyValue.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeBytesSize(KeyValue);
@@ -461,6 +491,12 @@ namespace Zynga.Protobuf.Runtime.EventSource {
       }
       if (other.MapAction != 0) {
         mapAction_ = other.MapAction;
+      }
+      if (other.key_ != null) {
+        if (key_ == null) {
+          key_ = new global::Zynga.Protobuf.Runtime.EventSource.MapKey();
+        }
+        Key.MergeFrom(other.Key);
       }
       if (other.KeyValue.Length != 0) {
         keyValue_ = other.KeyValue;
@@ -486,10 +522,17 @@ namespace Zynga.Protobuf.Runtime.EventSource {
             break;
           }
           case 18: {
-            keyValue_ = input.ReadBytes();
+            if (key_ == null) {
+              key_ = new global::Zynga.Protobuf.Runtime.EventSource.MapKey();
+            }
+            input.ReadMessage(key_);
             break;
           }
           case 26: {
+            keyValue_ = input.ReadBytes();
+            break;
+          }
+          case 34: {
             if (eventData_ == null) {
               eventData_ = new global::Zynga.Protobuf.Runtime.EventSource.EventData();
             }
@@ -1438,6 +1481,506 @@ namespace Zynga.Protobuf.Runtime.EventSource {
           case 90: {
             data_ = input.ReadBytes();
             dataCase_ = DataOneofCase.ByteData;
+            break;
+          }
+          case 96: {
+            data_ = input.ReadInt64();
+            dataCase_ = DataOneofCase.I64;
+            break;
+          }
+          case 104: {
+            data_ = input.ReadUInt64();
+            dataCase_ = DataOneofCase.U64;
+            break;
+          }
+          case 112: {
+            data_ = input.ReadSInt32();
+            dataCase_ = DataOneofCase.SI32;
+            break;
+          }
+          case 120: {
+            data_ = input.ReadSInt64();
+            dataCase_ = DataOneofCase.SI64;
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public sealed partial class MapKey : pb::IMessage<MapKey> {
+    private static readonly pb::MessageParser<MapKey> _parser = new pb::MessageParser<MapKey>(() => new MapKey());
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pb::MessageParser<MapKey> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Zynga.Protobuf.Runtime.EventSource.EventSourceReflection.Descriptor.MessageTypes[5]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MapKey() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MapKey(MapKey other) : this() {
+      switch (other.DataCase) {
+        case DataOneofCase.U32:
+          U32 = other.U32;
+          break;
+        case DataOneofCase.I32:
+          I32 = other.I32;
+          break;
+        case DataOneofCase.F64:
+          F64 = other.F64;
+          break;
+        case DataOneofCase.F32:
+          F32 = other.F32;
+          break;
+        case DataOneofCase.SF64:
+          SF64 = other.SF64;
+          break;
+        case DataOneofCase.SF32:
+          SF32 = other.SF32;
+          break;
+        case DataOneofCase.BoolData:
+          BoolData = other.BoolData;
+          break;
+        case DataOneofCase.StringData:
+          StringData = other.StringData;
+          break;
+        case DataOneofCase.I64:
+          I64 = other.I64;
+          break;
+        case DataOneofCase.U64:
+          U64 = other.U64;
+          break;
+        case DataOneofCase.SI32:
+          SI32 = other.SI32;
+          break;
+        case DataOneofCase.SI64:
+          SI64 = other.SI64;
+          break;
+      }
+
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public MapKey Clone() {
+      return new MapKey(this);
+    }
+
+    public static bool IsEventSourced = false;
+
+    /// <summary>Field number for the "u_32" field.</summary>
+    public const int U32FieldNumber = 1;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public uint U32 {
+      get { return dataCase_ == DataOneofCase.U32 ? (uint) data_ : 0; }
+      set {
+        data_ = value;
+        dataCase_ = DataOneofCase.U32;
+      }
+    }
+
+    /// <summary>Field number for the "i_32" field.</summary>
+    public const int I32FieldNumber = 2;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int I32 {
+      get { return dataCase_ == DataOneofCase.I32 ? (int) data_ : 0; }
+      set {
+        data_ = value;
+        dataCase_ = DataOneofCase.I32;
+      }
+    }
+
+    /// <summary>Field number for the "f_64" field.</summary>
+    public const int F64FieldNumber = 3;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ulong F64 {
+      get { return dataCase_ == DataOneofCase.F64 ? (ulong) data_ : 0UL; }
+      set {
+        data_ = value;
+        dataCase_ = DataOneofCase.F64;
+      }
+    }
+
+    /// <summary>Field number for the "f_32" field.</summary>
+    public const int F32FieldNumber = 4;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public uint F32 {
+      get { return dataCase_ == DataOneofCase.F32 ? (uint) data_ : 0; }
+      set {
+        data_ = value;
+        dataCase_ = DataOneofCase.F32;
+      }
+    }
+
+    /// <summary>Field number for the "s_f_64" field.</summary>
+    public const int SF64FieldNumber = 5;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public long SF64 {
+      get { return dataCase_ == DataOneofCase.SF64 ? (long) data_ : 0L; }
+      set {
+        data_ = value;
+        dataCase_ = DataOneofCase.SF64;
+      }
+    }
+
+    /// <summary>Field number for the "s_f_32" field.</summary>
+    public const int SF32FieldNumber = 6;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int SF32 {
+      get { return dataCase_ == DataOneofCase.SF32 ? (int) data_ : 0; }
+      set {
+        data_ = value;
+        dataCase_ = DataOneofCase.SF32;
+      }
+    }
+
+    /// <summary>Field number for the "bool_data" field.</summary>
+    public const int BoolDataFieldNumber = 9;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool BoolData {
+      get { return dataCase_ == DataOneofCase.BoolData ? (bool) data_ : false; }
+      set {
+        data_ = value;
+        dataCase_ = DataOneofCase.BoolData;
+      }
+    }
+
+    /// <summary>Field number for the "string_data" field.</summary>
+    public const int StringDataFieldNumber = 10;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string StringData {
+      get { return dataCase_ == DataOneofCase.StringData ? (string) data_ : ""; }
+      set {
+        data_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        dataCase_ = DataOneofCase.StringData;
+      }
+    }
+
+    /// <summary>Field number for the "i_64" field.</summary>
+    public const int I64FieldNumber = 12;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public long I64 {
+      get { return dataCase_ == DataOneofCase.I64 ? (long) data_ : 0L; }
+      set {
+        data_ = value;
+        dataCase_ = DataOneofCase.I64;
+      }
+    }
+
+    /// <summary>Field number for the "u_64" field.</summary>
+    public const int U64FieldNumber = 13;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public ulong U64 {
+      get { return dataCase_ == DataOneofCase.U64 ? (ulong) data_ : 0UL; }
+      set {
+        data_ = value;
+        dataCase_ = DataOneofCase.U64;
+      }
+    }
+
+    /// <summary>Field number for the "s_i_32" field.</summary>
+    public const int SI32FieldNumber = 14;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int SI32 {
+      get { return dataCase_ == DataOneofCase.SI32 ? (int) data_ : 0; }
+      set {
+        data_ = value;
+        dataCase_ = DataOneofCase.SI32;
+      }
+    }
+
+    /// <summary>Field number for the "s_i_64" field.</summary>
+    public const int SI64FieldNumber = 15;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public long SI64 {
+      get { return dataCase_ == DataOneofCase.SI64 ? (long) data_ : 0L; }
+      set {
+        data_ = value;
+        dataCase_ = DataOneofCase.SI64;
+      }
+    }
+
+    private object data_;
+    /// <summary>Enum of possible cases for the "data" oneof.</summary>
+    public enum DataOneofCase {
+      None = 0,
+      U32 = 1,
+      I32 = 2,
+      F64 = 3,
+      F32 = 4,
+      SF64 = 5,
+      SF32 = 6,
+      BoolData = 9,
+      StringData = 10,
+      I64 = 12,
+      U64 = 13,
+      SI32 = 14,
+      SI64 = 15,
+    }
+    private DataOneofCase dataCase_ = DataOneofCase.None;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public DataOneofCase DataCase {
+      get { return dataCase_; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void ClearData() {
+      dataCase_ = DataOneofCase.None;
+      data_ = null;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override bool Equals(object other) {
+      return Equals(other as MapKey);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public bool Equals(MapKey other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (U32 != other.U32) return false;
+      if (I32 != other.I32) return false;
+      if (F64 != other.F64) return false;
+      if (F32 != other.F32) return false;
+      if (SF64 != other.SF64) return false;
+      if (SF32 != other.SF32) return false;
+      if (BoolData != other.BoolData) return false;
+      if (StringData != other.StringData) return false;
+      if (I64 != other.I64) return false;
+      if (U64 != other.U64) return false;
+      if (SI32 != other.SI32) return false;
+      if (SI64 != other.SI64) return false;
+      if (DataCase != other.DataCase) return false;
+      return true;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (dataCase_ == DataOneofCase.U32) hash ^= U32.GetHashCode();
+      if (dataCase_ == DataOneofCase.I32) hash ^= I32.GetHashCode();
+      if (dataCase_ == DataOneofCase.F64) hash ^= F64.GetHashCode();
+      if (dataCase_ == DataOneofCase.F32) hash ^= F32.GetHashCode();
+      if (dataCase_ == DataOneofCase.SF64) hash ^= SF64.GetHashCode();
+      if (dataCase_ == DataOneofCase.SF32) hash ^= SF32.GetHashCode();
+      if (dataCase_ == DataOneofCase.BoolData) hash ^= BoolData.GetHashCode();
+      if (dataCase_ == DataOneofCase.StringData) hash ^= StringData.GetHashCode();
+      if (dataCase_ == DataOneofCase.I64) hash ^= I64.GetHashCode();
+      if (dataCase_ == DataOneofCase.U64) hash ^= U64.GetHashCode();
+      if (dataCase_ == DataOneofCase.SI32) hash ^= SI32.GetHashCode();
+      if (dataCase_ == DataOneofCase.SI64) hash ^= SI64.GetHashCode();
+      hash ^= (int) dataCase_;
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (dataCase_ == DataOneofCase.U32) {
+        output.WriteRawTag(8);
+        output.WriteUInt32(U32);
+      }
+      if (dataCase_ == DataOneofCase.I32) {
+        output.WriteRawTag(16);
+        output.WriteInt32(I32);
+      }
+      if (dataCase_ == DataOneofCase.F64) {
+        output.WriteRawTag(25);
+        output.WriteFixed64(F64);
+      }
+      if (dataCase_ == DataOneofCase.F32) {
+        output.WriteRawTag(37);
+        output.WriteFixed32(F32);
+      }
+      if (dataCase_ == DataOneofCase.SF64) {
+        output.WriteRawTag(41);
+        output.WriteSFixed64(SF64);
+      }
+      if (dataCase_ == DataOneofCase.SF32) {
+        output.WriteRawTag(53);
+        output.WriteSFixed32(SF32);
+      }
+      if (dataCase_ == DataOneofCase.BoolData) {
+        output.WriteRawTag(72);
+        output.WriteBool(BoolData);
+      }
+      if (dataCase_ == DataOneofCase.StringData) {
+        output.WriteRawTag(82);
+        output.WriteString(StringData);
+      }
+      if (dataCase_ == DataOneofCase.I64) {
+        output.WriteRawTag(96);
+        output.WriteInt64(I64);
+      }
+      if (dataCase_ == DataOneofCase.U64) {
+        output.WriteRawTag(104);
+        output.WriteUInt64(U64);
+      }
+      if (dataCase_ == DataOneofCase.SI32) {
+        output.WriteRawTag(112);
+        output.WriteSInt32(SI32);
+      }
+      if (dataCase_ == DataOneofCase.SI64) {
+        output.WriteRawTag(120);
+        output.WriteSInt64(SI64);
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public int CalculateSize() {
+      int size = 0;
+      if (dataCase_ == DataOneofCase.U32) {
+        size += 1 + pb::CodedOutputStream.ComputeUInt32Size(U32);
+      }
+      if (dataCase_ == DataOneofCase.I32) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(I32);
+      }
+      if (dataCase_ == DataOneofCase.F64) {
+        size += 1 + 8;
+      }
+      if (dataCase_ == DataOneofCase.F32) {
+        size += 1 + 4;
+      }
+      if (dataCase_ == DataOneofCase.SF64) {
+        size += 1 + 8;
+      }
+      if (dataCase_ == DataOneofCase.SF32) {
+        size += 1 + 4;
+      }
+      if (dataCase_ == DataOneofCase.BoolData) {
+        size += 1 + 1;
+      }
+      if (dataCase_ == DataOneofCase.StringData) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(StringData);
+      }
+      if (dataCase_ == DataOneofCase.I64) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(I64);
+      }
+      if (dataCase_ == DataOneofCase.U64) {
+        size += 1 + pb::CodedOutputStream.ComputeUInt64Size(U64);
+      }
+      if (dataCase_ == DataOneofCase.SI32) {
+        size += 1 + pb::CodedOutputStream.ComputeSInt32Size(SI32);
+      }
+      if (dataCase_ == DataOneofCase.SI64) {
+        size += 1 + pb::CodedOutputStream.ComputeSInt64Size(SI64);
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(MapKey other) {
+      if (other == null) {
+        return;
+      }
+      switch (other.DataCase) {
+        case DataOneofCase.U32:
+          U32 = other.U32;
+          break;
+        case DataOneofCase.I32:
+          I32 = other.I32;
+          break;
+        case DataOneofCase.F64:
+          F64 = other.F64;
+          break;
+        case DataOneofCase.F32:
+          F32 = other.F32;
+          break;
+        case DataOneofCase.SF64:
+          SF64 = other.SF64;
+          break;
+        case DataOneofCase.SF32:
+          SF32 = other.SF32;
+          break;
+        case DataOneofCase.BoolData:
+          BoolData = other.BoolData;
+          break;
+        case DataOneofCase.StringData:
+          StringData = other.StringData;
+          break;
+        case DataOneofCase.I64:
+          I64 = other.I64;
+          break;
+        case DataOneofCase.U64:
+          U64 = other.U64;
+          break;
+        case DataOneofCase.SI32:
+          SI32 = other.SI32;
+          break;
+        case DataOneofCase.SI64:
+          SI64 = other.SI64;
+          break;
+      }
+
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public void MergeFrom(pb::CodedInputStream input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 8: {
+            data_ = input.ReadUInt32();
+            dataCase_ = DataOneofCase.U32;
+            break;
+          }
+          case 16: {
+            data_ = input.ReadInt32();
+            dataCase_ = DataOneofCase.I32;
+            break;
+          }
+          case 25: {
+            data_ = input.ReadFixed64();
+            dataCase_ = DataOneofCase.F64;
+            break;
+          }
+          case 37: {
+            data_ = input.ReadFixed32();
+            dataCase_ = DataOneofCase.F32;
+            break;
+          }
+          case 41: {
+            data_ = input.ReadSFixed64();
+            dataCase_ = DataOneofCase.SF64;
+            break;
+          }
+          case 53: {
+            data_ = input.ReadSFixed32();
+            dataCase_ = DataOneofCase.SF32;
+            break;
+          }
+          case 72: {
+            data_ = input.ReadBool();
+            dataCase_ = DataOneofCase.BoolData;
+            break;
+          }
+          case 82: {
+            data_ = input.ReadString();
+            dataCase_ = DataOneofCase.StringData;
             break;
           }
           case 96: {

--- a/runtime/src/Zynga.Protobuf.Runtime/MapEventContext.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/MapEventContext.cs
@@ -1,5 +1,4 @@
-﻿using Google.Protobuf;
-using Zynga.Protobuf.Runtime.EventSource;
+﻿using Zynga.Protobuf.Runtime.EventSource;
 
 namespace Zynga.Protobuf.Runtime {
 	/// <summary>
@@ -8,13 +7,13 @@ namespace Zynga.Protobuf.Runtime {
 	/// </summary>
 	public class MapEventContext : EventContext {
 		private readonly EventContext _mapContext;
-		private readonly ByteString _key;
+		private readonly MapKey _key;
 		private readonly int _fieldNumber;
 
 		/// <summary>
 		/// Creates a MapContext Instance
 		/// </summary>
-		public MapEventContext(EventContext mapContext, ByteString key, int fieldNumber) {
+		public MapEventContext(EventContext mapContext, MapKey key, int fieldNumber) {
 			_mapContext = mapContext;
 			_key = key;
 			_fieldNumber = fieldNumber;
@@ -23,7 +22,7 @@ namespace Zynga.Protobuf.Runtime {
 		private void AddUpdateEvent(EventData data) {
 			var me = new MapEvent {
 				MapAction = MapAction.UpdateMap,
-				KeyValue = _key,
+				Key = _key,
 				EventData = data
 			};
 


### PR DESCRIPTION
Previously we were using the map codec support for extracting the key for event paths.  This turned out to be very expensive.  To address this we are moving to an explicit MapKey message. This should reduce 4 array allocs and make the json output more readable.