### PR TITLE
Lazily init EventContext collections

### DIFF
--- a/runtime/src/Zynga.Protobuf.Runtime/EventMapConverter.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventMapConverter.cs
@@ -4,8 +4,14 @@ using Zynga.Protobuf.Runtime.EventSource;
 
 namespace Zynga.Protobuf.Runtime {
 	public abstract class EventMapConverter<TKey, TValue> {
+		/// <summary>
+		/// Returns a MapKey object for the specified key
+		/// </summary>
 		public abstract MapKey GetMapKey(TKey key);
 
+		/// <summary>
+		/// Returns the key for the specified MapKey
+		/// </summary>
 		public abstract TKey GetKey(MapKey key);
 
 		/// <summary>

--- a/runtime/src/Zynga.Protobuf.Runtime/EventRegistry.cs
+++ b/runtime/src/Zynga.Protobuf.Runtime/EventRegistry.cs
@@ -70,7 +70,9 @@ namespace Zynga.Protobuf.Runtime {
 		/// <returns></returns>
 		public EventSourceRoot PeekEvents() {
 			var er = new EventSourceRoot();
-			er.Events.AddRange(Context.Events);
+			if (Context.Events != null) {
+				er.Events.AddRange(Context.Events);
+			}
 			return er;
 		}
 
@@ -78,7 +80,7 @@ namespace Zynga.Protobuf.Runtime {
 		/// Returns true if the object currently has Events
 		/// </summary>
 		public bool HasEvents {
-			get { return Context.Events.Count > 0; }
+			get { return Context.Events != null && Context.Events.Count > 0; }
 		}
 
 		/// <summary>


### PR DESCRIPTION
Many instances of the EventContext object will not need all of the collections initialized.  By moving to lazy initialization we can significantly reduce the number of unneeded allocations.